### PR TITLE
Upgrade flyway

### DIFF
--- a/applications/credhub-api/src/main/java/org/cloudfoundry/credhub/config/FlywayMigrationStrategyConfiguration.java
+++ b/applications/credhub-api/src/main/java/org/cloudfoundry/credhub/config/FlywayMigrationStrategyConfiguration.java
@@ -9,6 +9,10 @@ import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
 @Configuration
 public class FlywayMigrationStrategyConfiguration {
 
@@ -17,9 +21,25 @@ public class FlywayMigrationStrategyConfiguration {
     @Bean
     public FlywayMigrationStrategy repairBeforeMigration() {
         return flyway -> {
+            renameMigrationTableIfNeeded(flyway);
             repairIfNecessary(flyway);
             runMigration(flyway);
         };
+    }
+
+    private void renameMigrationTableIfNeeded(@NotNull Flyway flyway) {
+        try {
+            Connection connection = flyway.getConfiguration().getDataSource().getConnection();
+            LOGGER.info("Checking for existence of older 'schema_version' migration table");
+            ResultSet tables = connection.getMetaData().getTables(null, null, "schema_version", new String[]{"TABLE"});
+            if (tables.next()) {
+                LOGGER.info("Renaming 'schema_version' migration table to 'flyway_schema_history'");
+                connection.createStatement().execute("ALTER TABLE schema_version RENAME TO flyway_schema_history");
+            }
+        } catch (SQLException ex) {
+            LOGGER.fatal("Error renaming migration table.");
+            throw new FlywayException("Error renaming migration table", ex);
+        }
     }
 
     private void repairIfNecessary(@NotNull Flyway flyway) {

--- a/backends/shared-backend-configuration/src/main/kotlin/db/migration/common/V11_1__set_uuid_in_named_certificate_authority_where_null.kt
+++ b/backends/shared-backend-configuration/src/main/kotlin/db/migration/common/V11_1__set_uuid_in_named_certificate_authority_where_null.kt
@@ -1,12 +1,15 @@
 package db.migration.common
 
+import org.flywaydb.core.api.migration.BaseJavaMigration
 import java.util.UUID
-import org.flywaydb.core.api.migration.spring.SpringJdbcMigration
+import org.flywaydb.core.api.migration.Context
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
 
-class V11_1__set_uuid_in_named_certificate_authority_where_null : SpringJdbcMigration {
+class V11_1__set_uuid_in_named_certificate_authority_where_null : BaseJavaMigration() {
     @Throws(Exception::class)
-    override fun migrate(jdbcTemplate: JdbcTemplate) {
+    override fun migrate(context: Context) {
+        val jdbcTemplate = JdbcTemplate(SingleConnectionDataSource(context.connection, true))
         val nullUuidRecords = jdbcTemplate.queryForList(
             "select id from named_certificate_authority where uuid is null",
             Long::class.java)

--- a/backends/shared-backend-configuration/src/main/kotlin/db/migration/common/V20_1__set_uuid_in_encryption_key_canary.kt
+++ b/backends/shared-backend-configuration/src/main/kotlin/db/migration/common/V20_1__set_uuid_in_encryption_key_canary.kt
@@ -4,13 +4,16 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import java.sql.Types
 import java.util.UUID
 import org.cloudfoundry.credhub.utils.UuidUtil
-import org.flywaydb.core.api.migration.spring.SpringJdbcMigration
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
 
-class V20_1__set_uuid_in_encryption_key_canary : SpringJdbcMigration {
+class V20_1__set_uuid_in_encryption_key_canary : BaseJavaMigration() {
     @SuppressFBWarnings(value = ["NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"], justification = "The database will definitely exist")
     @Throws(Exception::class)
-    override fun migrate(jdbcTemplate: JdbcTemplate) {
+    override fun migrate(context: Context) {
+        val jdbcTemplate = JdbcTemplate(SingleConnectionDataSource(context.connection, true))
         val databaseName = jdbcTemplate
             .dataSource
             ?.getConnection()

--- a/backends/shared-backend-configuration/src/main/kotlin/db/migration/common/V25_1__add_secret_name_relation.kt
+++ b/backends/shared-backend-configuration/src/main/kotlin/db/migration/common/V25_1__add_secret_name_relation.kt
@@ -3,13 +3,16 @@ package db.migration.common
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import java.sql.Types
 import org.cloudfoundry.credhub.utils.UuidUtil
-import org.flywaydb.core.api.migration.spring.SpringJdbcMigration
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
 
-class V25_1__add_secret_name_relation : SpringJdbcMigration {
+class V25_1__add_secret_name_relation : BaseJavaMigration() {
     @SuppressFBWarnings(value = ["NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"], justification = "The database will definitely exist")
     @Throws(Exception::class)
-    override fun migrate(jdbcTemplate: JdbcTemplate) {
+    override fun migrate(context: Context) {
+        val jdbcTemplate = JdbcTemplate(SingleConnectionDataSource(context.connection, true))
         val databaseName = jdbcTemplate
             .dataSource
             ?.getConnection()

--- a/backends/shared-backend-configuration/src/main/kotlin/db/migration/common/V35_1__migrate_operation_audit_record_table.kt
+++ b/backends/shared-backend-configuration/src/main/kotlin/db/migration/common/V35_1__migrate_operation_audit_record_table.kt
@@ -3,13 +3,16 @@ package db.migration.common
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import java.sql.Types
 import org.cloudfoundry.credhub.utils.UuidUtil
-import org.flywaydb.core.api.migration.spring.SpringJdbcMigration
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
 
-class V35_1__migrate_operation_audit_record_table : SpringJdbcMigration {
+class V35_1__migrate_operation_audit_record_table : BaseJavaMigration() {
     @SuppressFBWarnings(value = ["NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"], justification = "The database will definitely exist")
     @Throws(Exception::class)
-    override fun migrate(jdbcTemplate: JdbcTemplate) {
+    override fun migrate(context: Context) {
+        val jdbcTemplate = JdbcTemplate(SingleConnectionDataSource(context.connection, true))
         val databaseName = jdbcTemplate
             .dataSource
             ?.getConnection()

--- a/backends/shared-backend-configuration/src/main/kotlin/db/migration/common/V41_1__set_salt_in_existing_user_credentials.kt
+++ b/backends/shared-backend-configuration/src/main/kotlin/db/migration/common/V41_1__set_salt_in_existing_user_credentials.kt
@@ -7,13 +7,16 @@ import java.sql.ResultSet
 import java.util.UUID
 import org.cloudfoundry.credhub.CryptSaltFactory
 import org.cloudfoundry.credhub.utils.UuidUtil
-import org.flywaydb.core.api.migration.spring.SpringJdbcMigration
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
 
-class V41_1__set_salt_in_existing_user_credentials : SpringJdbcMigration {
+class V41_1__set_salt_in_existing_user_credentials : BaseJavaMigration() {
     @SuppressFBWarnings(value = ["NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"], justification = "The database will definitely exist")
     @Throws(Exception::class)
-    override fun migrate(jdbcTemplate: JdbcTemplate) {
+    override fun migrate(context: Context) {
+        val jdbcTemplate = JdbcTemplate(SingleConnectionDataSource(context.connection, true))
         val databaseName = jdbcTemplate
             .dataSource
             ?.getConnection()
@@ -21,7 +24,7 @@ class V41_1__set_salt_in_existing_user_credentials : SpringJdbcMigration {
             ?.databaseProductName
             ?.toLowerCase()
         val saltFactory = CryptSaltFactory()
-        val uuids = jdbcTemplate.query("select uuid from user_credential") { rowSet: ResultSet, rowNum: Int ->
+        val uuids = jdbcTemplate.query("select uuid from user_credential") { rowSet: ResultSet, _: Int ->
             val uuidBytes = rowSet.getBytes("uuid")
             if ("postgresql" == databaseName) {
                 return@query UUID.fromString(String(uuidBytes, StandardCharsets.UTF_8))

--- a/backends/shared-backend-configuration/src/main/kotlin/db/migration/common/V44_2__migrate_encypted_values_to_encryped_value_table.kt
+++ b/backends/shared-backend-configuration/src/main/kotlin/db/migration/common/V44_2__migrate_encypted_values_to_encryped_value_table.kt
@@ -3,13 +3,16 @@ package db.migration.common
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import java.sql.Types
 import org.cloudfoundry.credhub.utils.UuidUtil
-import org.flywaydb.core.api.migration.spring.SpringJdbcMigration
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
 
-class V44_2__migrate_encypted_values_to_encryped_value_table : SpringJdbcMigration {
+class V44_2__migrate_encypted_values_to_encryped_value_table : BaseJavaMigration() {
     @SuppressFBWarnings(value = ["NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"], justification = "The database will definitely exist")
     @Throws(Exception::class)
-    override fun migrate(jdbcTemplate: JdbcTemplate) {
+    override fun migrate(context: Context) {
+        val jdbcTemplate = JdbcTemplate(SingleConnectionDataSource(context.connection, true))
         val databaseName = jdbcTemplate
             .dataSource
             ?.getConnection()

--- a/backends/shared-backend-configuration/src/main/kotlin/db/migration/common/V47_2__insert_checksum_values_for_existing_credentials.kt
+++ b/backends/shared-backend-configuration/src/main/kotlin/db/migration/common/V47_2__insert_checksum_values_for_existing_credentials.kt
@@ -1,12 +1,15 @@
 package db.migration.common
 
 import org.apache.commons.codec.digest.DigestUtils
-import org.flywaydb.core.api.migration.spring.SpringJdbcMigration
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
 
-class V47_2__insert_checksum_values_for_existing_credentials : SpringJdbcMigration {
+class V47_2__insert_checksum_values_for_existing_credentials : BaseJavaMigration() {
     @Throws(Exception::class)
-    override fun migrate(jdbcTemplate: JdbcTemplate) {
+    override fun migrate(context: Context) {
+        val jdbcTemplate = JdbcTemplate(SingleConnectionDataSource(context.connection, true))
         val credentials = jdbcTemplate.queryForRowSet("select * from credential")
         while (credentials.next()) {
             val credentialName = credentials.getString("name")

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         bcpkixFipsVersion = '1.0.2'
         bcFipsVersion = '1.0.1'
         commonsCodecVersion = '1.14' // remove this after deleting (now deprecated) spring-security-oauth2
-        flywayVersion = '5.2.4' // pinning to v5 because upgrading to v6+ directly breaks the upgrade of (v4->v5->v6) unless we can work around [this breaking change](https://stackoverflow.com/questions/49063385/flyway-5-0-7-warning-about-using-schema-version-table).
+        flywayVersion = '7.7.1'
         guavaVersion = '29.0-jre'
         h2Version = '1.4.199'
         jsonPathVersion = '2.4.0'


### PR DESCRIPTION
This allows support of postgres 13 which has been added to the bosh director

The issue with flyway v4 having a different default schema migrations table name
than flyway v5+ is resolved with a check that runs before migrating, and if the
old table is found, it is simply renamed to the new table.

We were able to run the application in dev mode against postgres just fine, and saw it migrate from the old table name to the new. But when we run tests, there seems to be some errors that show up because of possible changes in flyway that are not supported in the current version of spring boot.

We made an attempt to upgrade spring boot to resolve these errors, but we quickly got out of our element and rolled that work back.

Since the app seems to run, it may be possible to resolve the problem in how the tests are run instead of with a spring boot upgrade (although it does seem like it's time for a spring boot upgrade anyway).