### PR TITLE
manually bump springCloudContractVersion to 2.2.8

### DIFF
--- a/applications/credhub-api/build.gradle
+++ b/applications/credhub-api/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springCloudContractVersion = '2.2.3.RELEASE'
+        springCloudContractVersion = '2.2.8.RELEASE'
     }
     repositories {
         mavenCentral()


### PR DESCRIPTION
dependabot wants to bump to major version 3
- let's do this smaller bump first