### PR TITLE
Bump h2 DB to 1.4.200

### DIFF
--- a/applications/credhub-api/src/main/resources/db/migration/h2/V35__add_unknown_auth_method_to_request_audit_record.sql
+++ b/applications/credhub-api/src/main/resources/db/migration/h2/V35__add_unknown_auth_method_to_request_audit_record.sql
@@ -6,5 +6,5 @@ ALTER TABLE request_audit_record
   CHECK (auth_method IN ('uaa', 'mutual_tls', 'unknown'));
 
 ALTER TABLE `request_audit_record`
-  MODIFY `auth_method`
+  ALTER COLUMN `auth_method`
   VARCHAR(10) DEFAULT 'unknown' NOT NULL;

--- a/applications/credhub-api/src/main/resources/db/migration/h2/V44__create_encrypted_value_table.sql
+++ b/applications/credhub-api/src/main/resources/db/migration/h2/V44__create_encrypted_value_table.sql
@@ -3,7 +3,7 @@ CREATE CACHED TABLE encrypted_value (
   encryption_key_uuid BINARY(16) NOT NULL,
   encrypted_value BINARY(7016) NOT NULL,
   nonce BINARY(16) NOT NULL,
-  updated_at BIGINT NOT NULL,
+  updated_at BIGINT NOT NULL
 );
 
 ALTER TABLE encrypted_value

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         commonsCodecVersion = '1.15' // remove this after deleting (now deprecated) spring-security-oauth2
         flywayVersion = '7.15.0'
         guavaVersion = '31.1-jre'
-        h2Version = '1.4.199'
+        h2Version = '1.4.200'
         jsonPathVersion = '2.7.0'
         kotlinVersion = '1.5.32'
         ktlintVersion = '0.42.1'


### PR DESCRIPTION
- even though this is a patch, there are some "breaking changes".
Hence, adjusting sql syntax in this commit.
- use the standard alter table / alter column statement [as
  documented](https://h2database.com/html/commands.html#alter_table_alter_column)
- this version of h2 does not like the comma at the end of the
last column definition in create table statement...
- h2 is test DB only, so no implications in modifying DB migration files.

[#181598244]