### PR TITLE
Dependency cleanup

### DIFF
--- a/applications/credhub-api/build.gradle
+++ b/applications/credhub-api/build.gradle
@@ -71,10 +71,10 @@ dependencies {
     implementation("org.apache.commons:commons-lang3:${apacheCommonsLang3Version}")
     implementation("commons-codec:commons-codec:${commonsCodecVersion}")
 
-    implementation("org.apache.logging.log4j:log4j-api:${log4jVersion}")
-    implementation("org.apache.logging.log4j:log4j-core:${log4jVersion}")
-    implementation("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}")
+    implementation("org.apache.logging.log4j:log4j-api")
+    implementation("org.apache.logging.log4j:log4j-core")
+    implementation("org.apache.logging.log4j:log4j-jul")
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl")
 
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/build.gradle
+++ b/build.gradle
@@ -15,16 +15,15 @@ buildscript {
         jsonPathVersion = '2.7.0'
         kotlinVersion = '1.5.32'
         ktlintVersion = '0.42.1'
-        mariadbJdbcVersion = '2.7.5' // When using a MariaDB with a driver of version 2.4.0 or greater, FlyWay 5 does not know how to handle the driver reporting itself as "MariaDB" and will throw an exception causing CredHub to be unable to start. Do not upgrade until this issue is resolved. See #174776586.
+        mariadbJdbcVersion = '2.7.5'
         passayVersion = '1.6.1'
         postgresqlJdbcVersion = '42.3.4'
         spotBugsToolVersion = '4.6.0'
         springRestDocsVersion = '2.0.6.RELEASE'
-        springBootVersion = '2.5.12'
+        springBootVersion = '2.5.13'
         springSecurityOauth2Version = '2.5.1.RELEASE'
         springSecurityOauth2AutoconfigureVersion = '2.6.6'
         junitVersion = '4.13.2'
-        log4jVersion = '2.17.2' // this pinning can be removed when we bump to a spring boot starter version that has 2.17.1+ (due to CVE https://github.com/advisories/GHSA-jfh8-c2jp-5v3q in log4j <= 2.15.0)
     }
     repositories {
         mavenCentral()


### PR DESCRIPTION
is DB / flyway update possible now ? because in UAA it is still with fixed versions