### PR TITLE
Use credhub-release packaged version

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,8 +13,7 @@ jobs:
       - name: Setup JDK 8
         uses: actions/setup-java@v1
         with:
-          java-version: '1.8.0'
-          java-package: jdk
-          architecture: x86
+          distribution: 'liberica'
+          java-version: '8'
       - name: Build and test with Gradle
         run: ./gradlew clean build


### PR DESCRIPTION
Noticed that in credhub bosh release bellsoft JDK 8 is included, so use same here for unit tests