### PR TITLE
Fetch metadata in batches

### DIFF
--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultCertificatesHandlerIntegrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultCertificatesHandlerIntegrationTest.java
@@ -1,0 +1,65 @@
+package org.cloudfoundry.credhub.handlers;
+
+import org.cloudfoundry.credhub.CredhubTestApp;
+import org.cloudfoundry.credhub.certificates.DefaultCertificatesHandler;
+import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
+import org.cloudfoundry.credhub.views.CertificateCredentialsView;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(SpringRunner.class)
+@ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
+@SpringBootTest(classes = CredhubTestApp.class)
+public class DefaultCertificatesHandlerIntegrationTest {
+    @Autowired
+    private DefaultCertificatesHandler defaultCertificatesHandler;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private Environment environment;
+
+    @Before
+    public void setUp() throws Exception {
+        Assume.assumeTrue(
+                "Test is for Postgres only",
+                environment.acceptsProfiles(Profiles.of("unit-test-postgres")));
+        insertTestCredentialsIntoPostgres(32768);
+    }
+
+    @Test
+    public void handleGetAllRequest_32768Certs_doesNotCrash() {
+        CertificateCredentialsView certificateCredentialsView = defaultCertificatesHandler.handleGetAllRequest();
+        assertThat(certificateCredentialsView, is(notNullValue()));
+    }
+
+    private void insertTestCredentialsIntoPostgres(int count) {
+        jdbcTemplate.update(
+                "INSERT INTO credential (uuid, name, checksum) " +
+                        "SELECT uuid, name, uuid as checksum FROM (\n" +
+                        "    SELECT gen_random_uuid() as uuid, concat('certificate-', id) as name\n" +
+                        "                            FROM generate_series(1, ?) as id) foo", count);
+
+        jdbcTemplate.update(
+                "INSERT INTO credential_version (type, uuid, version_created_at, credential_uuid) " +
+                        "SELECT 'foo', uuid, 0, uuid from credential");
+
+        jdbcTemplate.update(
+                "INSERT INTO certificate_credential (uuid, transitional) " +
+                        "SELECT uuid, FALSE FROM credential");
+    }
+}

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultExceptionHandlerTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultExceptionHandlerTest.java
@@ -5,6 +5,7 @@ import javax.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,6 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringRunner.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
+@DirtiesContext
 @Transactional
 public class DefaultExceptionHandlerTest {
 

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateMinimumDurationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateMinimumDurationTest.java
@@ -8,6 +8,7 @@ import java.util.function.Consumer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -46,6 +47,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringRunner.class)
 @ActiveProfiles(profiles = { "unit-test", "minimum-duration", }, resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
+@DirtiesContext
 @Transactional
 public class CertificateMinimumDurationTest {
     private static final String CREDENTIAL_NAME = "/credential/name";

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialRegenerateTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialRegenerateTest.java
@@ -6,6 +6,7 @@ import java.util.function.Consumer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -65,6 +66,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
   resolver = DatabaseProfileResolver.class
 )
 @SpringBootTest(classes = CredhubTestApp.class)
+@DirtiesContext
 @Transactional
 @SuppressFBWarnings(
   value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/EncryptionKeyRotatorTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/EncryptionKeyRotatorTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -73,6 +74,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = CredhubTestApp.class)
 @RunWith(SpringRunner.class)
 @Transactional
+@DirtiesContext
 @SuppressFBWarnings(
   value = {
     "SS_SHOULD_BE_STATIC",

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/GenerateModeTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/GenerateModeTest.java
@@ -6,6 +6,7 @@ import java.util.function.Consumer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -42,6 +43,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringRunner.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
+@DirtiesContext
 @Transactional
 public class GenerateModeTest {
     private static final String CREDENTIAL_NAME = "/credential/name";

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsGenerateIntegrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsGenerateIntegrationTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -52,6 +53,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringRunner.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
+@DirtiesContext
 @Transactional
 public class CredentialsGenerateIntegrationTest {
 

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsGetIntegrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsGetIntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -68,6 +69,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(properties = {"certificates.concatenate_cas=false", })
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
+@DirtiesContext
 @SuppressFBWarnings
 public class CredentialsGetIntegrationTest {
 

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsTypeSpecificGenerateIntegrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsTypeSpecificGenerateIntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
@@ -81,6 +82,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(Parameterized.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
+@DirtiesContext
 @Transactional
 public class CredentialsTypeSpecificGenerateIntegrationTest {
 

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsTypeSpecificSetIntegrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsTypeSpecificSetIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
@@ -77,6 +78,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(Parameterized.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
+@DirtiesContext
 @Transactional
 public class CredentialsTypeSpecificSetIntegrationTest {
   @ClassRule

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/interpolation/InterpolationIntegrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/interpolation/InterpolationIntegrationTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -45,6 +46,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringRunner.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
+@DirtiesContext
 @Transactional
 public class InterpolationIntegrationTest {
   @Autowired

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/certificates/CertificatesGetConcatenateCasIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/certificates/CertificatesGetConcatenateCasIntegrationTest.kt
@@ -20,6 +20,7 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit4.SpringRunner
@@ -39,6 +40,7 @@ import java.util.UUID
 @ActiveProfiles(value = ["unit-test", "unit-test-permissions"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 @Transactional
+@DirtiesContext
 @TestPropertySource(properties = ["certificates.concatenate_cas=true"])
 class CertificatesGetConcatenateCasIntegrationTest {
     private val FROZEN_TIME = Instant.ofEpochSecond(1400011001L)

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/certificates/CertificatesGetIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/certificates/CertificatesGetIntegrationTest.kt
@@ -20,6 +20,7 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit4.SpringRunner
@@ -39,6 +40,7 @@ import java.util.UUID
 @ActiveProfiles(value = ["unit-test", "unit-test-permissions"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 @Transactional
+@DirtiesContext
 @TestPropertySource(properties = ["certificates.concatenate_cas=false"])
 class CertificatesGetIntegrationTest {
     private val FROZEN_TIME = Instant.ofEpochSecond(1400011001L)

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsGetConcatenateCasIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsGetConcatenateCasIntegrationTest.kt
@@ -21,6 +21,7 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit4.SpringRunner
@@ -40,6 +41,7 @@ import java.util.UUID
 @RunWith(SpringRunner::class)
 @ActiveProfiles(value = ["unit-test", "unit-test-permissions"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
+@DirtiesContext
 @Transactional
 @TestPropertySource(properties = ["certificates.concatenate_cas=true"])
 class CredentialsGetConcatenateCasIntegrationTest {

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsPostIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsPostIntegrationTest.kt
@@ -18,6 +18,7 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit4.SpringRunner
@@ -34,6 +35,7 @@ import java.time.Instant
 @ActiveProfiles(value = ["unit-test", "unit-test-permissions"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 @Transactional
+@DirtiesContext
 @TestPropertySource(properties = ["certificates.concatenate_cas=false"])
 class CredentialsPostIntegrationTest {
     private val FROZEN_TIME = Instant.ofEpochSecond(1400011001L)

--- a/components/credentials/src/test/kotlin/org/cloudfoundry/credhub/services/CertificateDataServiceTest.kt
+++ b/components/credentials/src/test/kotlin/org/cloudfoundry/credhub/services/CertificateDataServiceTest.kt
@@ -15,6 +15,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 @RunWith(SpringRunner::class)
 @ActiveProfiles(value = ["unit-test"], resolver = DatabaseProfileResolver::class)
@@ -36,7 +37,7 @@ class CertificateDataServiceTest {
         val caName = "/some-ca"
         val otherName = "some-other-credential"
         val otherCaName = "/some-other-ca"
-        val expectedExpiryDate = Instant.now()
+        val expectedExpiryDate = Instant.now().truncatedTo(ChronoUnit.MILLIS)
         val certificateCredentialVersionData = CertificateCredentialVersionData(name)
         val otherCertificateCredentialVersionData = CertificateCredentialVersionData(otherName)
         certificateCredentialVersionData.caName = caName

--- a/components/test-support/src/test/kotlin/org/cloudfoundry/credhub/config/ParallelPostgresTestDataSourceConfiguration.kt
+++ b/components/test-support/src/test/kotlin/org/cloudfoundry/credhub/config/ParallelPostgresTestDataSourceConfiguration.kt
@@ -1,5 +1,6 @@
 package org.cloudfoundry.credhub.config
 
+import com.zaxxer.hikari.HikariDataSource
 import org.springframework.boot.jdbc.DataSourceBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -38,7 +39,7 @@ class ParallelPostgresTestDataSourceConfiguration {
             jdbcTemplate.execute("CREATE DATABASE $workerDatabaseName")
         }
 
-        tempDataSource.connection.close()
+        (tempDataSource as HikariDataSource).close()
     }
 
     @Primary
@@ -52,7 +53,14 @@ class ParallelPostgresTestDataSourceConfiguration {
         val dataSource = DataSourceBuilder.create()
             .url("jdbc:postgresql://localhost:5432/credhub_test_$workerId?user=pivotal")
             .build()
+        configureConnectionPool(dataSource)
 
         return dataSource
+    }
+
+    private fun configureConnectionPool(dataSource: DataSource) {
+        (dataSource as HikariDataSource).idleTimeout = 5000
+        dataSource.maximumPoolSize = 10
+        dataSource.minimumIdle = 0
     }
 }

--- a/scripts/run_mariadb_in_docker.sh
+++ b/scripts/run_mariadb_in_docker.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+container_name="credhub-mysql-dev"
+db_name="credhub_test"
+
+main() {
+  trap "cleanup" EXIT
+
+  setup &
+  setup_pid=$!
+
+  docker run \
+    --name "${container_name}" \
+    --rm \
+    -p 3306:3306 \
+    -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=true \
+    docker.io/library/mariadb
+}
+
+cleanup() {
+  echo "Stopping MariaDB..."
+  docker kill "${container_name}"
+  kill "$setup_pid" 2>/dev/null
+}
+
+setup() {
+  sleep 1
+  try_connect
+  echo -n "Configuring dev-database... "
+  docker exec -it "${container_name}" bash -c "echo create database ${db_name}\; | mysql"
+  echo "done"
+}
+
+try_connect() {
+  started=1
+  while [[ "$started" != "0" ]]
+  do
+    sleep 1
+    echo "Attempting to connect to MariaDB..."
+    set +e
+    docker exec "${container_name}" bash -c "echo select 1\; | mysql" &>/dev/null
+    started=$?
+    set -e
+  done
+}
+
+main

--- a/scripts/run_postgres_in_docker.sh
+++ b/scripts/run_postgres_in_docker.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+container_name="credhub-postgres-dev"
+db_names="credhub_test pivotal"
+username="pivotal"
+
+main() {
+  trap "cleanup" EXIT
+
+  setup &
+  setup_pid=$!
+
+  docker run \
+    --name "${container_name}" \
+    --rm \
+    -p 5432:5432 \
+    -e POSTGRES_HOST_AUTH_METHOD=trust \
+    docker.io/library/postgres
+}
+
+cleanup() {
+  echo "Stopping Postgres..."
+  docker kill "${container_name}"
+  kill "$setup_pid" 2>/dev/null
+}
+
+setup() {
+  sleep 1
+  try_connect
+  echo -n "Configuring dev-user and database... "
+  docker exec -it "${container_name}" createuser -U postgres --createdb "${username}"
+  for db_name in ${db_names}
+  do
+    docker exec -it "${container_name}" createdb -U "${username}" "${db_name}"
+  done
+
+  echo "done"
+}
+
+try_connect() {
+  started=1
+  while [[ "$started" != "0" ]]
+  do
+    sleep 1
+    echo "Attempting to connect to Postgres..."
+    set +e
+    docker exec "${container_name}" psql -U postgres -v "ON_ERROR_STOP=1" -c "SELECT 1" >/dev/null
+    started=$?
+    set -e
+  done
+}
+
+main


### PR DESCRIPTION
This fixes an issue with Postgres and instances with >= 32768 certificates
available to a user.

CertificateDataService.findAllValidMetadata(names) puts all cert names in a
single IN (...) SQL query, which JdbcTemplate turns into a query with a bind
variable for each cert name (IN (?, ?, ?, ...)). This exhausts Postgres's
per-query bind variable limit.

Fixes https://github.com/cloudfoundry/credhub/issues/340

The PR also includes

* Local DB automation
* Fixes I needed to make existing tests pass with Postgres and MySQL
* A commit adding a couple of `@DirtiesContext` annotations, helping with resource consumption