### PR TITLE
fix: tests timeout when generating certs

### DIFF
--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateTest.java
@@ -29,11 +29,13 @@ import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.ErrorMessages;
 import org.cloudfoundry.credhub.helpers.JsonTestHelper;
+import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.utils.TestConstants;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -83,6 +85,11 @@ public class CertificateGenerateTest {
 
     @Rule
     public Timeout globalTimeout = Timeout.seconds(900);
+
+    @BeforeClass
+    public static void beforeAll() {
+        BouncyCastleFipsConfigurer.configure();
+    }
 
     @Before
     public void beforeEach() {

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateWithoutAclEnforcementTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateWithoutAclEnforcementTest.java
@@ -12,8 +12,10 @@ import org.springframework.web.context.WebApplicationContext;
 
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.helpers.RequestHelper;
+import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -40,6 +42,11 @@ public class CertificateGenerateWithoutAclEnforcementTest {
 
   @Rule
   public Timeout globalTimeout = Timeout.seconds(900);
+
+  @BeforeClass
+  public static void beforeAll() {
+    BouncyCastleFipsConfigurer.configure();
+  }
 
   @Before
   public void beforeEach() throws Exception {

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGetTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGetTest.java
@@ -17,9 +17,11 @@ import org.springframework.web.context.WebApplicationContext;
 import com.jayway.jsonpath.JsonPath;
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.helpers.RequestHelper;
+import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONArray;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -62,6 +64,11 @@ public class CertificateGetTest {
 
   @Rule
   public Timeout globalTimeout = Timeout.seconds(900);
+
+  @BeforeClass
+  public static void beforeAll() {
+    BouncyCastleFipsConfigurer.configure();
+  }
 
   @Before
   public void beforeEach() throws Exception {

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateVersionDeleteTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateVersionDeleteTest.java
@@ -14,9 +14,11 @@ import org.springframework.web.context.WebApplicationContext;
 import com.jayway.jsonpath.JsonPath;
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.helpers.RequestHelper;
+import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONArray;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -53,6 +55,11 @@ public class CertificateVersionDeleteTest {
 
   @Rule
   public Timeout globalTimeout = Timeout.seconds(900);
+
+  @BeforeClass
+  public static void beforeAll() {
+    BouncyCastleFipsConfigurer.configure();
+  }
 
   @Before
   public void beforeEach() throws Exception {

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialGetTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialGetTest.java
@@ -17,9 +17,11 @@ import org.springframework.web.context.WebApplicationContext;
 import com.jayway.jsonpath.JsonPath;
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.helpers.RequestHelper;
+import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONObject;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -55,6 +57,11 @@ public class CredentialGetTest {
 
   @Rule
   public Timeout globalTimeout = Timeout.seconds(900);
+
+  @BeforeClass
+  public static void beforeAll() {
+    BouncyCastleFipsConfigurer.configure();
+  }
 
   @Before
   public void beforeEach() throws Exception {

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/certificates/CertificatesPostIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/certificates/CertificatesPostIntegrationTest.kt
@@ -7,6 +7,7 @@ import org.cloudfoundry.credhub.helpers.RequestHelper.generateCertificateCredent
 import org.cloudfoundry.credhub.helpers.RequestHelper.getCertificateId
 import org.cloudfoundry.credhub.helpers.RequestHelper.regenerateCertificate
 import org.cloudfoundry.credhub.utils.AuthConstants.Companion.ALL_PERMISSIONS_TOKEN
+import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.cloudfoundry.credhub.utils.CertificateReader
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver
 import org.hamcrest.core.IsEqual.equalTo
@@ -14,6 +15,7 @@ import org.junit.Assert
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertThat
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.Timeout
@@ -50,6 +52,14 @@ class CertificatesPostIntegrationTest {
     private lateinit var mockMvc: MockMvc
     private var caCertificate: String? = null
     private var caCredentialUuid: String = ""
+
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun setUpAll() {
+            BouncyCastleFipsConfigurer.configure()
+        }
+    }
 
     @Before
     @Throws(Exception::class)

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/regneration/RegenerateEndpointConcatenateCasIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/regneration/RegenerateEndpointConcatenateCasIntegrationTest.kt
@@ -4,11 +4,13 @@ import com.jayway.jsonpath.JsonPath
 import org.cloudfoundry.credhub.CredhubTestApp
 import org.cloudfoundry.credhub.helpers.RequestHelper
 import org.cloudfoundry.credhub.utils.AuthConstants.Companion.ALL_PERMISSIONS_TOKEN
+import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.cloudfoundry.credhub.utils.CertificateReader
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver
 import org.hamcrest.core.IsEqual
 import org.junit.Assert
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.Timeout
@@ -45,6 +47,14 @@ class RegenerateEndpointConcatenateCasIntegrationTest {
 
     @get:Rule
     val globalTimeout: Timeout = Timeout.seconds(900)
+
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun setUpAll() {
+            BouncyCastleFipsConfigurer.configure()
+        }
+    }
 
     @Before
     fun beforeEach() {


### PR DESCRIPTION
- When Concourse CI was upgraded to v7, some of our tests start
to timeout. These tests all generate certificates. Our current
theory is that the Concourse upgrade made the test run env take
longer to gather enough initial entropy; and these failed tests
are still using "Blocking" random generation algorithm (where the
generation process is "blocked" when the system is still trying
to gather enough entropy).
- We also observed that these slow tests are all invoking
[RequestHelper.generateCertificateCredential](https://github.com/cloudfoundry/credhub/blob/76c8c92296ecb4ef38889c9c163b38e9b7968346/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/helpers/RequestHelper.kt#L205)
to generate certificates.
- Previously, to ensure that a non-blocking entropy source is used,
we configure the bc-fips provider to use `NativePRNGBlocking`
SecureRandom by default in production and in some tests (https://github.com/cloudfoundry/credhub/commit/fbca28aef14cb1cb03505ee60f0074f87816a30e). In this commit, we extend this non-blocking
configuration to all tests that are using `RequestHelper.generateCertificateCredential`
in order to fix these test timeouts.

[#182659311]