### PR TITLE
Pin notAfter dates for certificates to max out at signing CA notAfter date

### DIFF
--- a/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/SignedCertificateGenerator.java
+++ b/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/SignedCertificateGenerator.java
@@ -93,11 +93,24 @@ public class SignedCertificateGenerator {
 
     final BigInteger certificateSerialNumber = serialNumberGenerator.generate();
 
+    Date nvb = Date.from(now);
+    Data nva = Date.from(now.plus(Duration.ofDays(params.getDuration())));
+    if (issuerCertificate != null) {
+      // don't allow a child certificate to be valid before the signing certificate
+      if (nvb.isBefore(issuerCertificate.getNotBefore())) {
+        nvb = issuerCertificate.getNotBefore();
+      }
+      // don't allow a child certificate to be valid after the signing certificate
+      if (nva.isAfter(issuerCertificate.getNotAfter())) {
+        nva = issuerCertificate.getNotAfter();
+      }
+    }
+
     final JcaX509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(
       issuerDn,
       certificateSerialNumber,
-      Date.from(now),
-      Date.from(now.plus(Duration.ofDays(params.getDuration()))),
+      nvb,
+      nva,
       params.getX500Principal(),
       keyPair.getPublic()
     );


### PR DESCRIPTION
This prevents one from issuing a certificate that appears to be valid, but in reality typically won't validate as being so.

Partially fixes #377