### PR TITLE
fix Postgres running out of connections

### DIFF
--- a/components/test-support/src/test/kotlin/org/cloudfoundry/credhub/config/ParallelPostgresTestDataSourceConfiguration.kt
+++ b/components/test-support/src/test/kotlin/org/cloudfoundry/credhub/config/ParallelPostgresTestDataSourceConfiguration.kt
@@ -1,5 +1,6 @@
 package org.cloudfoundry.credhub.config
 
+import com.zaxxer.hikari.HikariDataSource
 import org.springframework.boot.jdbc.DataSourceBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -38,7 +39,7 @@ class ParallelPostgresTestDataSourceConfiguration {
             jdbcTemplate.execute("CREATE DATABASE $workerDatabaseName")
         }
 
-        tempDataSource.connection.close()
+        (tempDataSource as HikariDataSource).close()
     }
 
     @Primary
@@ -52,7 +53,14 @@ class ParallelPostgresTestDataSourceConfiguration {
         val dataSource = DataSourceBuilder.create()
             .url("jdbc:postgresql://localhost:5432/credhub_test_$workerId?user=pivotal")
             .build()
+        configureConnectionPool(dataSource)
 
         return dataSource
+    }
+
+    private fun configureConnectionPool(dataSource: DataSource) {
+        (dataSource as HikariDataSource).idleTimeout = 5000
+        dataSource.maximumPoolSize = 10
+        dataSource.minimumIdle = 0
     }
 }


### PR DESCRIPTION
This fixes an issue in which Postgres would run out of available connections, causing tests to fail.

* Close tempDataSource in createTestDatabaseForWorker()
* Configure connection pool in getParallelTestDataSource() to close idle connections after 5s and scale to 0

Written by @andreasf 