### PR TITLE
Simplify dependencies

### DIFF
--- a/applications/credhub-api/build.gradle
+++ b/applications/credhub-api/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation('org.springframework.cloud:spring-cloud-starter-contract-verifier')
-    testImplementation("junit:junit:${junitVersion}")
+    testImplementation("junit:junit")
 }
 
 configurations.all {

--- a/applications/credhub-api/build.gradle
+++ b/applications/credhub-api/build.gradle
@@ -71,11 +71,6 @@ dependencies {
     implementation("org.apache.commons:commons-lang3:${apacheCommonsLang3Version}")
     implementation("commons-codec:commons-codec:${commonsCodecVersion}")
 
-    implementation("org.apache.logging.log4j:log4j-api")
-    implementation("org.apache.logging.log4j:log4j-core")
-    implementation("org.apache.logging.log4j:log4j-jul")
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl")
-
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/backends/credhub/build.gradle
+++ b/backends/credhub/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-validation')
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit:${junitVersion}")
+    testImplementation("junit:junit")
 
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ buildscript {
         springBootVersion = '2.7.6'
         springSecurityOauth2Version = '2.5.2.RELEASE'
         springSecurityOauth2AutoconfigureVersion = '2.6.8'
-        junitVersion = '4.13.2'
         mariadbJdbcVersion = '2.7.7' // Bumping to v3 breaks some pipeline jobs, so pinning to v2 for now. v2 (current version) is stable and will be supported until about September 2025 (https://mariadb.com/kb/en/about-mariadb-connector-j/).
     }
     repositories {

--- a/components/audit/build.gradle
+++ b/components/audit/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation('org.springframework.boot:spring-boot-starter-security')
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit:${junitVersion}")
+    testImplementation("junit:junit")
 
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/components/auth/build.gradle
+++ b/components/auth/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation("org.springframework.security.oauth:spring-security-oauth2:${springSecurityOauth2Version}")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit:${junitVersion}")
+    testImplementation("junit:junit")
 
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/components/credentials/build.gradle
+++ b/components/credentials/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-security')
     implementation('org.springframework.boot:spring-boot-starter-validation')
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit:${junitVersion}")
+    testImplementation("junit:junit")
 
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/components/encryption/build.gradle
+++ b/components/encryption/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit:${junitVersion}")
+    testImplementation("junit:junit")
 
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/components/errors/build.gradle
+++ b/components/errors/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-validation')
     implementation("org.springframework.security.oauth:spring-security-oauth2:${springSecurityOauth2Version}")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit:${junitVersion}")
+    testImplementation("junit:junit")
 
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/components/generate/build.gradle
+++ b/components/generate/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation('org.springframework.boot:spring-boot-starter-validation')
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit:${junitVersion}")
+    testImplementation("junit:junit")
 
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/components/management/build.gradle
+++ b/components/management/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}")
     implementation("org.springframework.security.oauth:spring-security-oauth2:${springSecurityOauth2Version}")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit:${junitVersion}")
+    testImplementation("junit:junit")
     testImplementation project(path: ":components:test-support", configuration: "testOutput")
 
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')

--- a/components/permissions/build.gradle
+++ b/components/permissions/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation('org.springframework.boot:spring-boot-starter-validation')
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit:${junitVersion}")
+    testImplementation("junit:junit")
 
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/components/string-utilities/build.gradle
+++ b/components/string-utilities/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit:${junitVersion}")
+    testImplementation("junit:junit")
 
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/components/time-support/build.gradle
+++ b/components/time-support/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit:${junitVersion}")
+    testImplementation("junit:junit")
 
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")


### PR DESCRIPTION
jUnit versions will be handled by Spring. Remove log4j dependency declarations to simplify future analysis.