### PR TITLE
Migrate to Java 11

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup JDK 8
+      - name: Setup JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: 'liberica'
-          java-version: '8'
+          java-version: '11'
       - name: Build and test with Gradle
         run: ./gradlew clean build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM openjdk:8 as build
+FROM openjdk:11 as build
 WORKDIR /app
 COPY . /app
 RUN ./gradlew bootJar -x test -x check
 
-FROM openjdk:8-jre as run
+FROM openjdk:11-jre as run
 WORKDIR /app
 COPY \
   --from=build \

--- a/README.md
+++ b/README.md
@@ -88,31 +88,6 @@ Configuration for the server is spread across the `application*.yml` files.
 
 By default, CredHub launches with the `dev-h2` and `dev` profiles enabled.
 
-#### Oracle JDK vs OpenJDK
-
-CredHub relies on the JDK to have uncrippled cryptographic capability -- in the Oracle JDK, this requires the slightly deceptively named "Unlimited Strength Jurisdiction Policy".
-
-By default, OpenJDK ships with "Unlimited Strength". Our credhub-release uses OpenJDK, and so inherits the full-strength capability.
-
-But the Oracle JDK is often installed on workstations and does _not_ have the Unlimited Strength policy.
-
-##### How can I tell?
-
-If you see an error like `java.security.InvalidKeyException: Illegal key size`, you probably haven't installed the additional policy for the Oracle JDK. CredHub is trying to use 256-bit keys, but is being blocked by the default policy.
-
-##### Resolving
-
-Oracle makes the Unlimited Strength policy available for [separate download here](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html).
-
-Assuming you are on OS X, you can then run:
-
-```
-unzip ~/Downloads/jce_policy-8.zip -d /tmp
-sudo cp /tmp/UnlimitedJCEPolicyJDK8/*.jar "$(/usr/libexec/java_home)/jre/lib/security/"
-```
-
-You will need to restart CredHub locally for changes to take effect.
-
 #### UAA and the JWT public signing key
 
 CredHub requires a [UAA server](https://github.com/cloudfoundry/uaa) to manage authentication.

--- a/applications/credhub-api/build.gradle
+++ b/applications/credhub-api/build.gradle
@@ -72,7 +72,6 @@ dependencies {
     implementation("commons-codec:commons-codec:${commonsCodecVersion}")
 
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
     testImplementation("org.springframework.security:spring-security-test")

--- a/applications/credhub-api/src/main/resources/db/migration/mysql/V56__change_expiry_date_in_certificate_credential.sql
+++ b/applications/credhub-api/src/main/resources/db/migration/mysql/V56__change_expiry_date_in_certificate_credential.sql
@@ -1,0 +1,2 @@
+ALTER TABLE certificate_credential
+  MODIFY expiry_date datetime(6);

--- a/kotlin.gradle
+++ b/kotlin.gradle
@@ -1,12 +1,12 @@
 compileKotlin {
     kotlinOptions {
         freeCompilerArgs = ["-Xjsr305=strict", "-Xjvm-default=all-compatibility"]
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 }
 compileTestKotlin {
     kotlinOptions {
         freeCompilerArgs = ["-Xjsr305=strict", "-Xjvm-default=all-compatibility"]
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 }


### PR DESCRIPTION
Using Java 11 now instead of Java 8, so that we can upgrade the HikariCP library.

This will be coordinated with a PR in credhub-release.

[#184142402]