### PR TITLE
fix: update dependency repository ordering

### DIFF
--- a/backends/credhub/build.gradle
+++ b/backends/credhub/build.gradle
@@ -4,8 +4,9 @@ buildscript {
     }
     repositories {
         mavenCentral()
-        maven { url("https://repo.spring.io/plugins-release") }
+        jcenter()
         maven { url("https://plugins.gradle.org/m2/") }
+        maven { url("https://repo.spring.io/plugins-release") }
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion")

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
-        maven { url("https://repo.spring.io/plugins-release") }
         maven { url("https://plugins.gradle.org/m2/") }
+        maven { url("https://repo.spring.io/plugins-release") }
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")


### PR DESCRIPTION
This ensures the build works with recent access restrictions on repo.spring.io