### PR TITLE
fix: Gradle clean build fails while downloading dependencies as follows:

### DIFF
--- a/backends/credhub/build.gradle
+++ b/backends/credhub/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion")
         classpath("org.asciidoctor:asciidoctor-gradle-plugin:${asciiDoctorPluginVersion}")
         classpath("com.google.protobuf:protobuf-gradle-plugin:0.9.3")
+        classpath("org.ysb33r.gradle:grolifant:0.16.1")
     }
 }
 


### PR DESCRIPTION
```
A problem occurred configuring project ':backends:credhub'.
> Could not resolve all artifacts for configuration ':backends:credhub:classpath'.
   > Could not resolve org.ysb33r.gradle:grolifant:0.10.
     Required by:
         project :backends:credhub > org.asciidoctor:asciidoctor-gradle-plugin:1.6.1
      > Could not resolve org.ysb33r.gradle:grolifant:0.10.
         > Could not get resource 'https://repo.spring.io/plugins-release/org/ysb33r/gradle/grolifant/0.10/grolifant-0.10.pom'.

            > Could not GET 'https://repo.spring.io/plugins-release/org/ysb33r/gradle/grolifant/0.10/grolifant-0.10.pom'. Received status code 401 from server:
```

- Override the gradle buildscript's transitive dependency of asciidoctor with grolifant 0.16.1, which is available in maven central.

[#185464175]