### PR TITLE
fix: Missing asciidoctor transitive dependencies in maven repositories

### DIFF
--- a/backends/credhub/build.gradle
+++ b/backends/credhub/build.gradle
@@ -9,9 +9,8 @@ buildscript {
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion")
-        classpath("org.asciidoctor:asciidoctor-gradle-plugin:${asciiDoctorPluginVersion}")
+        classpath("org.asciidoctor.convert:org.asciidoctor.convert.gradle.plugin:${asciiDoctorConvertPluginVersion}")
         classpath("com.google.protobuf:protobuf-gradle-plugin:0.9.3")
-        classpath("org.ysb33r.gradle:grolifant:0.16.1")
     }
 }
 
@@ -31,6 +30,7 @@ apply plugin: "com.google.protobuf"
 
 repositories {
     mavenCentral()
+    maven { url("https://plugins.gradle.org/m2/") }
     jcenter()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         apacheCommonsLang3Version = '3.12.0'
         apacheCommonsIoVersion = '2.13.0'
         apacheHttpClientVersion = '4.5.14'
-        asciiDoctorPluginVersion = '1.6.1'
+        asciiDoctorConvertPluginVersion = '2.4.0'
         bcpkixFipsVersion = '1.0.7'
         bcFipsVersion = '1.0.2.3'
         commonsCodecVersion = '1.16.0' // remove this after deleting (now deprecated) spring-security-oauth2


### PR DESCRIPTION
- Declare dependency to 'org.asciidoctor.convert.gradle.plugin' instead of `asciidoctor-gradle-plugin` and overriding 'grolifant' version. 'org.asciidoctor.convert.gradle.plugin' 2.4.0 has dependencies to later versions of 'asciidoctor-gradle-jvm and 'grolifant'.
- Add gradle plugin maven repository in build repositories for the asciidoctor task.

[#185464175]