### PR TITLE
Revert "Build(deps): bump grpcVersion from 1.56.1 to 1.57.0"

### DIFF
--- a/backends/credhub/build.gradle
+++ b/backends/credhub/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        grpcVersion = '1.57.0'
+        grpcVersion = '1.56.1'
     }
     repositories {
         mavenCentral()

--- a/backends/remote/build.gradle
+++ b/backends/remote/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        grpcVersion = '1.57.0'
+        grpcVersion = '1.56.1'
         nettyVersion = '4.1.96.Final'
     }
     repositories {

--- a/components/credentials/build.gradle
+++ b/components/credentials/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        grpcVersion = '1.57.0'
+        grpcVersion = '1.56.1'
     }
     repositories {
         mavenCentral()

--- a/components/encryption/build.gradle
+++ b/components/encryption/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        grpcVersion = '1.57.0'
+        grpcVersion = '1.56.1'
         nettyVersion = '4.1.96.Final'
     }
     repositories {


### PR DESCRIPTION
Reverts cloudfoundry/credhub#546 due to repeated test failures here: https://runway-ci.eng.vmware.com/teams/tas-journey-auth/pipelines/credhub-edge/jobs/test-kms-plugin-integration-jammy/builds/600.5