### PR TITLE
Revert "Non-Trivial - Test Failures in CI - Build(deps): bump grpcVersion from 1.56.1 to 1.57.0"

### DIFF
--- a/backends/credhub/build.gradle
+++ b/backends/credhub/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        grpcVersion = '1.57.0'
+        grpcVersion = '1.56.1'
     }
     repositories {
         mavenCentral()

--- a/backends/remote/build.gradle
+++ b/backends/remote/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        grpcVersion = '1.57.0'
+        grpcVersion = '1.56.1'
         nettyVersion = '4.1.96.Final'
     }
     repositories {

--- a/components/credentials/build.gradle
+++ b/components/credentials/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        grpcVersion = '1.57.0'
+        grpcVersion = '1.56.1'
     }
     repositories {
         mavenCentral()

--- a/components/encryption/build.gradle
+++ b/components/encryption/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        grpcVersion = '1.57.0'
+        grpcVersion = '1.56.1'
         nettyVersion = '4.1.96.Final'
     }
     repositories {


### PR DESCRIPTION
Reverts cloudfoundry/credhub#550 because it breaks a CI job related to testing KMS. Story: https://www.pivotaltracker.com/story/show/185733631