### PR TITLE
fix: Incorrect not-rotated record count log message

### DIFF
--- a/components/encryption/src/main/java/org/cloudfoundry/credhub/services/EncryptionKeyRotator.java
+++ b/components/encryption/src/main/java/org/cloudfoundry/credhub/services/EncryptionKeyRotator.java
@@ -59,8 +59,9 @@ public class EncryptionKeyRotator {
     if (rotatedRecordCount == 0) {
       LOGGER.info("Found no records in need of encryption key rotation.");
     } else {
-      LOGGER.info("Finished encryption key rotation in " + duration + " milliseconds. Details:");
-      LOGGER.info("  Successfully rotated " + rotatedRecordCount + " item(s)");
+      LOGGER.info("Finished encryption key rotation in " + duration +
+              " milliseconds. Details: Successfully rotated " +
+              rotatedRecordCount + " item(s)");
     }
 
     encryptionKeyCanaryMapper.delete(inactiveCanaries);

--- a/components/encryption/src/main/java/org/cloudfoundry/credhub/services/EncryptionKeyRotator.java
+++ b/components/encryption/src/main/java/org/cloudfoundry/credhub/services/EncryptionKeyRotator.java
@@ -38,9 +38,6 @@ public class EncryptionKeyRotator {
     LOGGER.info("Starting encryption key rotation.");
     int rotatedRecordCount = 0;
 
-    final long startingNotRotatedRecordCount = encryptedValueDataService
-      .countAllByCanaryUuid(keySet.getActive().getUuid());
-
     final List<UUID> inactiveCanaries = keySet.getInactiveUuids();
     Slice<EncryptedValue> valuesEncryptedByOldKey = encryptedValueDataService
       .findByCanaryUuids(inactiveCanaries);
@@ -58,15 +55,12 @@ public class EncryptionKeyRotator {
 
     final long finish = System.currentTimeMillis();
     final long duration = finish - start;
-    final long endingNotRotatedRecordCount = startingNotRotatedRecordCount - rotatedRecordCount;
 
-    if (rotatedRecordCount == 0 && endingNotRotatedRecordCount == 0) {
+    if (rotatedRecordCount == 0) {
       LOGGER.info("Found no records in need of encryption key rotation.");
     } else {
       LOGGER.info("Finished encryption key rotation in " + duration + " milliseconds. Details:");
       LOGGER.info("  Successfully rotated " + rotatedRecordCount + " item(s)");
-      LOGGER.info("  Skipped " + endingNotRotatedRecordCount
-        + " item(s) due to missing master encryption key(s).");
     }
 
     encryptionKeyCanaryMapper.delete(inactiveCanaries);


### PR DESCRIPTION
- As the rotated count can be greater than the starting count.
- Removed the log message.

[#185977500]