### PR TITLE
Add separate GitHub workflow config for unit-testing java11 branch

### DIFF
--- a/.github/workflows/unit-test-java11.yml
+++ b/.github/workflows/unit-test-java11.yml
@@ -1,8 +1,8 @@
-name: unit-test
+name: unit-test-java11
 
 on:
   push:
-    branches-ignore:
+    branches:
       - '**java11'
 
 permissions:
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup JDK 8
+      - name: Setup JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'liberica'
-          java-version: '8'
+          java-version: '11'
       - name: Build and test with Gradle
         run: ./gradlew clean build


### PR DESCRIPTION
- So as to use Java11 in the branch, while keep using Java8 in other branches

[#184142402]