### PR TITLE
doc: remove section on crippled cryptographic capability in Oracle JDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,31 +88,6 @@ Configuration for the server is spread across the `application*.yml` files.
 
 By default, CredHub launches with the `dev-h2` and `dev` profiles enabled.
 
-#### Oracle JDK vs OpenJDK
-
-CredHub relies on the JDK to have uncrippled cryptographic capability -- in the Oracle JDK, this requires the slightly deceptively named "Unlimited Strength Jurisdiction Policy".
-
-By default, OpenJDK ships with "Unlimited Strength". Our credhub-release uses OpenJDK, and so inherits the full-strength capability.
-
-But the Oracle JDK is often installed on workstations and does _not_ have the Unlimited Strength policy.
-
-##### How can I tell?
-
-If you see an error like `java.security.InvalidKeyException: Illegal key size`, you probably haven't installed the additional policy for the Oracle JDK. CredHub is trying to use 256-bit keys, but is being blocked by the default policy.
-
-##### Resolving
-
-Oracle makes the Unlimited Strength policy available for [separate download here](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html).
-
-Assuming you are on OS X, you can then run:
-
-```
-unzip ~/Downloads/jce_policy-8.zip -d /tmp
-sudo cp /tmp/UnlimitedJCEPolicyJDK8/*.jar "$(/usr/libexec/java_home)/jre/lib/security/"
-```
-
-You will need to restart CredHub locally for changes to take effect.
-
 #### UAA and the JWT public signing key
 
 CredHub requires a [UAA server](https://github.com/cloudfoundry/uaa) to manage authentication.


### PR DESCRIPTION
* On https://www.oracle.com/java/technologies/javase-jce-all-downloads.html it says "JDK 9 and later offer the stronger cryptographic algorithms by default."
* CredHub now requires Java 11+.
* Have not tested CredHub with the Oracle JRE.

[#184142402]