### PR TITLE
bump: The Java version in credhub Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM openjdk:11 as build
+FROM bellsoft/liberica-openjdk-debian:17 as build
 WORKDIR /app
 COPY . /app
 RUN ./gradlew bootJar -x test -x check
 
-FROM openjdk:11-jre as run
+FROM bellsoft/liberica-openjre-debian:17 as run
 WORKDIR /app
 COPY \
   --from=build \


### PR DESCRIPTION
- Bump JDK & JRE to 17.
- Switch the base image to BellSoft one as there is no separate jre image for openjdk 17.
- Also, we package credhub with BellSoft JRE so using BellSoft Java image makes sense.

[#186054022]

_Approve but do not merge. I will merge the change along with other bump changes later._