### PR TITLE
fix: exclude unused vulnerable transitive dep bcprov-jdk15on

### DIFF
--- a/applications/credhub-api/build.gradle
+++ b/applications/credhub-api/build.gradle
@@ -51,7 +51,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.security:spring-security-web")
     implementation('org.springframework.boot:spring-boot-starter-security')
-    implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}")
+    implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}") {
+        exclude(module: "bcprov-jdk15on")
+    }
     implementation("org.springframework.security.oauth:spring-security-oauth2:${springSecurityOauth2Version}")
 
     testImplementation project(path: ":components:test-support", configuration: "testOutput")

--- a/backends/remote/build.gradle
+++ b/backends/remote/build.gradle
@@ -41,7 +41,9 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}")
+    implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}") {
+        exclude(module: "bcprov-jdk15on")
+    }
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 
     implementation('com.fasterxml.jackson.module:jackson-module-kotlin')

--- a/components/auth/build.gradle
+++ b/components/auth/build.gradle
@@ -35,7 +35,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.security:spring-security-web")
     implementation('org.springframework.boot:spring-boot-starter-security')
-    implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}")
+    implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}") {
+        exclude(module: "bcprov-jdk15on")
+    }
     implementation("org.springframework.security.oauth:spring-security-oauth2:${springSecurityOauth2Version}")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/components/encryption/build.gradle
+++ b/components/encryption/build.gradle
@@ -41,7 +41,9 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}")
+    implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}") {
+        exclude(module: "bcprov-jdk15on")
+    }
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("junit:junit")
 

--- a/components/management/build.gradle
+++ b/components/management/build.gradle
@@ -29,7 +29,9 @@ dependencies {
     implementation project(":components:errors")
 
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}")
+    implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}") {
+        exclude(module: "bcprov-jdk15on")
+    }
     implementation("org.springframework.security.oauth:spring-security-oauth2:${springSecurityOauth2Version}")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("junit:junit")

--- a/components/test-support/build.gradle
+++ b/components/test-support/build.gradle
@@ -31,7 +31,9 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}")
+    implementation("org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}") {
+        exclude(module: "bcprov-jdk15on")
+    }
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation('org.springframework.boot:spring-boot-starter-validation')
 


### PR DESCRIPTION
- bcprov-jdk15on is a transitive dep we get from using spring-security-oauth2-autoconfigure, which is an EOL lib (and hence does not have further patches) we will replace.
- The bcprov-jdk15on version here is flagged with CVE-2020-0187 and CVE-2023-33201.
- Exclude bcprov-jdk15on to address these CVEs.
- gradle doc on the exclude statement: https://docs.gradle.org/current/userguide/dependency_downgrade_and_exclude.html#sec:excluding-transitive-deps