### PR TITLE
fix build error with netty bump

### DIFF
--- a/backends/remote/build.gradle
+++ b/backends/remote/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     ext {
         grpcVersion = '1.60.1'
-        nettyVersion = '4.1.101.Final'
     }
     repositories {
         mavenCentral()
@@ -63,9 +62,9 @@ dependencies {
     implementation "io.grpc:grpc-netty:${grpcVersion}"
 
     //Netty
-    implementation "io.netty:netty-transport-native-unix-common:${nettyVersion}"
-    implementation "io.netty:netty-all:${nettyVersion}"
-    implementation "io.netty:netty-codec-http2:${nettyVersion}"
+    implementation "io.netty:netty-transport-native-unix-common"
+    implementation "io.netty:netty-all"
+    implementation "io.netty:netty-codec-http2"
 
     //tcnative
     implementation "io.netty:netty-tcnative-boringssl-static:2.0.62.Final"

--- a/components/encryption/build.gradle
+++ b/components/encryption/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     ext {
         grpcVersion = '1.60.1'
-        nettyVersion = '4.1.101.Final'
     }
     repositories {
         mavenCentral()
@@ -74,8 +73,8 @@ dependencies {
     implementation "io.grpc:grpc-netty:${grpcVersion}"
 
     //Netty
-    implementation "io.netty:netty-transport-native-unix-common:${nettyVersion}"
-    implementation "io.netty:netty-all:${nettyVersion}"
+    implementation "io.netty:netty-transport-native-unix-common"
+    implementation "io.netty:netty-all"
 }
 
 dependencyManagement {


### PR DESCRIPTION
* Had a build error related to grpc-netty trying to pin netty to 4.1.102 or 4.1.104:
```
   > Could not find netty-transport-native-epoll-4.1.101.Final-linux-riscv64.jar (io.netty:netty-transport-native-epoll:4.1.101.Final).
```
* Could not find a reason to pin the netty version. We're hoping the original reason is no longer valid.

[#186764106]