### PR TITLE
bump: Spring Framework to 5.3.32

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ buildscript {
         classpath("org.bouncycastle:bc-fips:${bcFipsVersion}")
         classpath("org.bouncycastle:bcpkix-fips:${bcpkixFipsVersion}")
     }
+
+    // Versions we're overriding from the Spring Boot Bom
+    ext["spring-framework.version"] = "5.3.32" // Bumping to latest version 5 patch for CVE-2024-22243
 }
 
 plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,11 @@ buildscript {
     }
 
     // Versions we're overriding from the Spring Boot Bom
-    ext["spring-framework.version"] = "5.3.32" // Bumping to latest version 5 patch for CVE-2024-22243
+
+    // spring-boot 2.7.18 has dependency to spring-framework 5.3.31, which has
+    // CVE-2024-22243. So, override that with spring-framework 5 latest patch
+    // version. This should be removed once spring-boot version is bumped.
+    ext["spring-framework.version"] = "5.3.32"
 }
 
 plugins {


### PR DESCRIPTION
- As it is latest version 5 patch and CVE-free.

[#187137257]