### PR TITLE
182121168 del encrypted values 2

### DIFF
--- a/applications/credhub-api/src/main/resources/db/migration/h2/V57_2__delete_related_encrypted_value_when_credential_is_deleted.sql
+++ b/applications/credhub-api/src/main/resources/db/migration/h2/V57_2__delete_related_encrypted_value_when_credential_is_deleted.sql
@@ -1,0 +1,20 @@
+-- Delete the encrypted_value record that was associated
+-- with the deleted credential_version record.
+DROP TRIGGER IF EXISTS tr_credential_version_post_del;
+CREATE TRIGGER tr_credential_version_post_del
+AFTER DELETE ON credential_version
+FOR EACH ROW CALL "org.cloudfoundry.credhub.data.CredentialVersionDeleteTrigger";
+
+-- Delete the encrypted_value record that was associated
+-- with the deleted password_credential record.
+DROP TRIGGER IF EXISTS tr_password_credential_post_del;
+CREATE TRIGGER tr_password_credential_post_del
+AFTER DELETE ON password_credential
+FOR EACH ROW CALL "org.cloudfoundry.credhub.data.PasswordOrUserCredentialDeleteTrigger";
+
+-- Delete the encrypted_value record that was associated
+-- with the deleted user_credential record.
+DROP TRIGGER IF EXISTS tr_user_credential_post_del;
+CREATE TRIGGER tr_user_credential_post_del
+AFTER DELETE ON user_credential
+FOR EACH ROW CALL "org.cloudfoundry.credhub.data.PasswordOrUserCredentialDeleteTrigger";

--- a/applications/credhub-api/src/main/resources/db/migration/mysql/V57_2__delete_related_encrypted_value_when_credential_is_deleted.sql
+++ b/applications/credhub-api/src/main/resources/db/migration/mysql/V57_2__delete_related_encrypted_value_when_credential_is_deleted.sql
@@ -1,0 +1,53 @@
+-- Fix for https://github.com/cloudfoundry/credhub/issues/231
+
+-- Trigger to delete encrypted_value records that are associated with
+-- passowrd_credential or user_credential when a credential is deleted.
+DROP TRIGGER IF EXISTS tr_credential_version_pre_del;
+DELIMITER |
+CREATE TRIGGER tr_credential_version_pre_del BEFORE DELETE ON credential_version
+FOR EACH ROW
+BEGIN
+    DECLARE enc_val_id BINARY(16);
+
+    -- For each record that is referencing encrypted_value record,
+    -- set FKs to encrypted_value to null before deleting the encrypted_value
+    -- record. Otherwise, the referencing record cannot be deleted because of
+    -- the FK constraint.
+    IF OLD.type = 'password' THEN
+        SELECT password_parameters_uuid from password_credential
+            WHERE uuid = OLD.uuid INTO enc_val_id;
+        UPDATE password_credential SET password_parameters_uuid = NULL
+            WHERE uuid = OLD.uuid;
+        DELETE FROM encrypted_value WHERE uuid = enc_val_id;
+    ELSEIF OLD.type = 'user' THEN
+        SELECT password_parameters_uuid from user_credential
+            WHERE uuid = OLD.uuid INTO enc_val_id;
+        UPDATE user_credential SET password_parameters_uuid = NULL
+            WHERE uuid = OLD.uuid;
+        DELETE FROM encrypted_value WHERE uuid = enc_val_id;
+    END IF;
+END;
+|
+DELIMITER ;
+
+-- Trigger to delete the encrypted_values records that are associated
+-- with the credential_version record when a credential_version was
+-- deleted.
+DROP TRIGGER IF EXISTS tr_credential_version_post_del;
+CREATE TRIGGER tr_credential_version_post_del AFTER DELETE ON credential_version
+FOR EACH ROW
+    -- Delete the encrypted_value record that is associated with the
+    -- credential_version record.
+    DELETE FROM encrypted_value WHERE uuid = OLD.encrypted_value_uuid;
+
+-- Trigger to delete all associated encrypted_value records when a credential
+-- is deleted. Needed to define one on credential table to work around the MySQL
+-- trigger limitation where the triggers on cascade-deleted records are not
+-- executed.
+DROP TRIGGER IF EXISTS tr_credential_pre_del;
+CREATE TRIGGER tr_credential_pre_del BEFORE DELETE ON credential
+FOR EACH ROW
+    -- Delete the child record here instead of relying on casecasde-delete, as
+    -- MySQL trigger on the child table does not get executed when
+    -- cascade-deleteed.
+    DELETE FROM credential_version WHERE credential_uuid = OLD.uuid;

--- a/applications/credhub-api/src/main/resources/db/migration/postgres/V57_2__delete_related_encrypted_value_when_credential_is_deleted.sql
+++ b/applications/credhub-api/src/main/resources/db/migration/postgres/V57_2__delete_related_encrypted_value_when_credential_is_deleted.sql
@@ -1,0 +1,40 @@
+-- Fix for https://github.com/cloudfoundry/credhub/issues/231
+
+-- Delete the encrypted_values records that are associated
+-- with the credential_version record when a credential_version was
+-- deleted.
+
+CREATE OR REPLACE FUNCTION del_credential_version_encrypted_value()
+RETURNS TRiGGER AS $$
+BEGIN
+    DELETE FROM encrypted_value WHERE uuid = OLD.encrypted_value_uuid;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS tr_credential_version_post_del ON credential_version;
+CREATE TRIGGER tr_credential_version_post_del
+AFTER DELETE ON credential_version
+FOR EACH ROW EXECUTE FUNCTION del_credential_version_encrypted_value();
+
+-- Delete the encrypted_values records that are associated
+-- with the password_credential record or the user_credential record when the
+-- credential record was deleted.
+
+CREATE OR REPLACE FUNCTION del_user_or_password_credential_encrypted_value()
+RETURNS TRiGGER AS $$
+BEGIN
+    DELETE FROM encrypted_value WHERE uuid = OLD.password_parameters_uuid;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS tr_password_credential_post_del ON password_credential;
+CREATE TRIGGER tr_password_credential_post_del
+AFTER DELETE ON password_credential
+FOR EACH ROW EXECUTE FUNCTION del_user_or_password_credential_encrypted_value();
+
+DROP TRIGGER IF EXISTS tr_user_credential_post_del ON user_credential;
+CREATE TRIGGER tr_user_credential_post_del
+AFTER DELETE ON user_credential
+FOR EACH ROW EXECUTE FUNCTION del_user_or_password_credential_encrypted_value();

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateVersionDeleteTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateVersionDeleteTest.java
@@ -1,5 +1,7 @@
 package org.cloudfoundry.credhub.integration;
 
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -13,6 +15,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import com.jayway.jsonpath.JsonPath;
 import org.cloudfoundry.credhub.CredhubTestApp;
+import org.cloudfoundry.credhub.data.EncryptedValueDataService;
 import org.cloudfoundry.credhub.helpers.RequestHelper;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
@@ -51,6 +54,9 @@ public class CertificateVersionDeleteTest {
   @Autowired
   private WebApplicationContext webApplicationContext;
 
+  @Autowired
+  EncryptedValueDataService encryptedValueDataService;
+
   private MockMvc mockMvc;
 
   @Rule
@@ -71,6 +77,9 @@ public class CertificateVersionDeleteTest {
 
   @Test
   public void deleteCertificateVersion_whenThereAreOtherVersionsOfTheCertificate_deletesTheSpecifiedVersion() throws Exception {
+    UUID aUuid = UUID.randomUUID();
+    var nEncrypredValuesPre = encryptedValueDataService.countAllByCanaryUuid(aUuid);
+
     final String credentialName = "/test-certificate";
 
     String response = generateCertificateCredential(mockMvc, credentialName, true, "test", null, ALL_PERMISSIONS_TOKEN);
@@ -81,13 +90,14 @@ public class CertificateVersionDeleteTest {
       .read("$.certificates[0].id");
 
     final String version = RequestHelper.regenerateCertificate(mockMvc, uuid, false, ALL_PERMISSIONS_TOKEN);
+    assertThat("One associated encrypted value exist for each certificate vesion",
+            encryptedValueDataService.countAllByCanaryUuid(aUuid), equalTo(nEncrypredValuesPre + 2));
+
     final String versionUuid = JsonPath.parse(version).read("$.id");
     final String versionValue = JsonPath.parse(version).read("$.value.certificate");
-
     final MockHttpServletRequestBuilder request = delete("/api/v1/certificates/" + uuid + "/versions/" + versionUuid)
       .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
       .accept(APPLICATION_JSON);
-
     response = mockMvc.perform(request)
       .andExpect(status().isOk())
       .andReturn().getResponse().getContentAsString();
@@ -103,6 +113,8 @@ public class CertificateVersionDeleteTest {
     final JSONArray jsonArray = new JSONArray(response);
     assertThat(jsonArray.length(), equalTo(1));
     assertThat(JsonPath.parse(jsonArray.get(0).toString()).read("$.value.certificate"), equalTo(nonDeletedVersion));
+    assertThat("Associated encrypted value is deleted when the certificate version is deleted",
+            encryptedValueDataService.countAllByCanaryUuid(aUuid), equalTo(nEncrypredValuesPre + 1));
   }
 
   @Test

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/CredentialVersionData.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/CredentialVersionData.kt
@@ -45,7 +45,12 @@ abstract class CredentialVersionData<Z : CredentialVersionData<Z>>(credential: C
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     var uuid: UUID? = null
 
-    @OneToOne(cascade = [CascadeType.ALL])
+    @OneToOne(
+        cascade = [
+            CascadeType.PERSIST, CascadeType.MERGE,
+            CascadeType.REFRESH, CascadeType.DETACH
+        ]
+    )
     @NotFound(action = NotFoundAction.IGNORE)
     @JoinColumn(name = "encrypted_value_uuid")
     var encryptedCredentialValue: EncryptedValue? = null

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/services/DefaultCredentialVersionDataServiceTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/services/DefaultCredentialVersionDataServiceTest.java
@@ -312,13 +312,8 @@ public class DefaultCredentialVersionDataServiceTest {
 
     assertThat(subject.findAllByName("/my-credential"), hasSize(0));
     assertNull(credentialDataService.find("/my-credential"));
-
-    if (!"unit-test-h2".equals(activeSpringProfile)) {
-      System.out.println("Asserting on the record count because the active spring profile is " + activeSpringProfile);
-
-      assertEquals("Associated encryptedValues are deleted when password credential is deleted",
-              nEncryptedValuesPre, encryptedValueRepository.count());
-    }
+    assertEquals("Associated encryptedValues are deleted when password credential is deleted",
+            nEncryptedValuesPre, encryptedValueRepository.count());
   }
 
   @Test
@@ -353,13 +348,8 @@ public class DefaultCredentialVersionDataServiceTest {
     subject.delete("/MY-CREDENTIAL");
 
     assertThat(subject.findAllByName("/my-credential"), empty());
-
-    if (!"unit-test-h2".equals(activeSpringProfile)) {
-      System.out.println("Asserting on the record count because the active spring profile is " + activeSpringProfile);
-
-      assertEquals("Associated encryptedValues are deleted when password credential is deleted",
-              nEncryptedValuesPre, encryptedValueRepository.count());
-    }
+    assertEquals("Associated encryptedValues are deleted when password credential is deleted",
+            nEncryptedValuesPre, encryptedValueRepository.count());
   }
 
   @Test
@@ -396,12 +386,8 @@ public class DefaultCredentialVersionDataServiceTest {
 
     subject.delete("/my-credential");
     assertThat(subject.findAllByName("/my-credential"), empty());
-    if (!"unit-test-h2".equals(activeSpringProfile)) {
-      System.out.println("Asserting on the record count because the active spring profile is " + activeSpringProfile);
-
-      assertEquals("Associated encryptedValues are deleted when user credential is deleted",
-              nEncryptedValuesPre, encryptedValueRepository.count());
-    }
+    assertEquals("Associated encryptedValues are deleted when user credential is deleted",
+            nEncryptedValuesPre, encryptedValueRepository.count());
   }
 
   @Test

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/services/DefaultCredentialVersionDataServiceTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/services/DefaultCredentialVersionDataServiceTest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.function.Consumer;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -31,11 +32,13 @@ import org.cloudfoundry.credhub.entity.Credential;
 import org.cloudfoundry.credhub.entity.CredentialVersionData;
 import org.cloudfoundry.credhub.entity.PasswordCredentialVersionData;
 import org.cloudfoundry.credhub.entity.SshCredentialVersionData;
+import org.cloudfoundry.credhub.entity.UserCredentialVersionData;
 import org.cloudfoundry.credhub.entity.ValueCredentialVersionData;
 import org.cloudfoundry.credhub.exceptions.MaximumSizeException;
 import org.cloudfoundry.credhub.exceptions.ParameterizedValidationException;
 import org.cloudfoundry.credhub.repositories.CredentialRepository;
 import org.cloudfoundry.credhub.repositories.CredentialVersionRepository;
+import org.cloudfoundry.credhub.repositories.EncryptedValueRepository;
 import org.cloudfoundry.credhub.util.CurrentTimeProvider;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.utils.DatabaseUtilities;
@@ -60,6 +63,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -70,11 +74,17 @@ import static org.junit.Assert.assertThat;
 @Transactional
 public class DefaultCredentialVersionDataServiceTest {
 
+  @Value("${spring.profiles.active}")
+  private String activeSpringProfile;
+
   @Autowired
   private CredentialVersionRepository credentialVersionRepository;
 
   @Autowired
   private CredentialRepository credentialRepository;
+
+  @Autowired
+  private EncryptedValueRepository encryptedValueRepository;
 
   @Autowired
   private EncryptionKeyCanaryDataService encryptionKeyCanaryDataService;
@@ -272,6 +282,7 @@ public class DefaultCredentialVersionDataServiceTest {
 
   @Test
   public void delete_onACredentialName_deletesAllCredentialsWithTheName() {
+    long nEncryptedValuesPre = encryptedValueRepository.count();
     final Credential credential = credentialDataService
       .save(new Credential("/my-credential"));
 
@@ -301,10 +312,18 @@ public class DefaultCredentialVersionDataServiceTest {
 
     assertThat(subject.findAllByName("/my-credential"), hasSize(0));
     assertNull(credentialDataService.find("/my-credential"));
+
+    if (!"unit-test-h2".equals(activeSpringProfile)) {
+      System.out.println("Asserting on the record count because the active spring profile is " + activeSpringProfile);
+
+      assertEquals("Associated encryptedValues are deleted when password credential is deleted",
+              nEncryptedValuesPre, encryptedValueRepository.count());
+    }
   }
 
   @Test
   public void delete_givenACredentialNameCasedDifferentlyFromTheActual_shouldBeCaseInsensitive() {
+    long nEncryptedValuesPre = encryptedValueRepository.count();
     final Credential credentialName = credentialDataService
       .save(new Credential("/my-credential"));
 
@@ -334,6 +353,55 @@ public class DefaultCredentialVersionDataServiceTest {
     subject.delete("/MY-CREDENTIAL");
 
     assertThat(subject.findAllByName("/my-credential"), empty());
+
+    if (!"unit-test-h2".equals(activeSpringProfile)) {
+      System.out.println("Asserting on the record count because the active spring profile is " + activeSpringProfile);
+
+      assertEquals("Associated encryptedValues are deleted when password credential is deleted",
+              nEncryptedValuesPre, encryptedValueRepository.count());
+    }
+  }
+
+  @Test
+  public void delete_UserTypeCredential() {
+    long nEncryptedValuesPre = encryptedValueRepository.count();
+    final Credential credentialName = credentialDataService.save(
+            new Credential("/my-credential"));
+
+    final EncryptedValue encryptedValueA = new EncryptedValue();
+    encryptedValueA.setEncryptionKeyUuid(activeCanaryUuid);
+    encryptedValueA.setEncryptedValue("credential-password".getBytes(UTF_8));
+    encryptedValueA.setNonce(new byte[]{});
+
+    final UserCredentialVersionData credentialDataA =
+            new UserCredentialVersionData("test-user");
+    credentialDataA.setCredential(credentialName);
+    credentialDataA.setEncryptedValueData(encryptedValueA);
+    credentialDataA.setSalt("salt");
+    subject.save(credentialDataA);
+
+    final EncryptedValue encryptedValueB = new EncryptedValue();
+    encryptedValueB.setEncryptionKeyUuid(activeCanaryUuid);
+    encryptedValueB.setEncryptedValue("another password".getBytes(UTF_8));
+    encryptedValueB.setNonce(new byte[]{});
+
+    final UserCredentialVersionData credentialDataB = new UserCredentialVersionData(
+            "/my-credential");
+    credentialDataB.setCredential(credentialName);
+    credentialDataB.setEncryptedValueData(encryptedValueB);
+    credentialDataB.setSalt("salt");
+    subject.save(credentialDataB);
+
+    assertThat(subject.findAllByName("/my-credential"), hasSize(2));
+
+    subject.delete("/my-credential");
+    assertThat(subject.findAllByName("/my-credential"), empty());
+    if (!"unit-test-h2".equals(activeSpringProfile)) {
+      System.out.println("Asserting on the record count because the active spring profile is " + activeSpringProfile);
+
+      assertEquals("Associated encryptedValues are deleted when user credential is deleted",
+              nEncryptedValuesPre, encryptedValueRepository.count());
+    }
   }
 
   @Test

--- a/components/encryption/src/main/java/org/cloudfoundry/credhub/data/CredentialVersionDeleteTrigger.java
+++ b/components/encryption/src/main/java/org/cloudfoundry/credhub/data/CredentialVersionDeleteTrigger.java
@@ -1,0 +1,23 @@
+package org.cloudfoundry.credhub.data;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.h2.tools.TriggerAdapter;
+
+/**
+ * H2 trigger for credential_version record deletion
+ */
+public class CredentialVersionDeleteTrigger extends TriggerAdapter {
+    @Override
+    public void fire(Connection conn, ResultSet oldRow, ResultSet newRow)
+            throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "DELETE FROM encrypted_value WHERE uuid = ?")) {
+            stmt.setObject(1, oldRow.getObject("encrypted_value_uuid"));
+            stmt.executeUpdate();
+        }
+    }
+}

--- a/components/encryption/src/main/java/org/cloudfoundry/credhub/data/PasswordOrUserCredentialDeleteTrigger.java
+++ b/components/encryption/src/main/java/org/cloudfoundry/credhub/data/PasswordOrUserCredentialDeleteTrigger.java
@@ -1,0 +1,23 @@
+package org.cloudfoundry.credhub.data;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.h2.tools.TriggerAdapter;
+
+/**
+ * H2 trigger for password_credential or user_credential record deletion
+ */
+public class PasswordOrUserCredentialDeleteTrigger extends TriggerAdapter {
+    @Override
+    public void fire(Connection conn, ResultSet oldRow, ResultSet newRow)
+            throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+                "DELETE FROM encrypted_value WHERE uuid = ?")) {
+            stmt.setObject(1, oldRow.getObject("password_parameters_uuid"));
+            stmt.executeUpdate();
+        }
+    }
+}


### PR DESCRIPTION
Fix for issue https://github.com/cloudfoundry/credhub/issues/231

Changes include:
- Database triggers to delete encrypted_value records when `credential` or `credential_version` is deleted
- Removal of cacscade delete in JPA entity for credential_version as it interferes with the database triggers 