### PR TITLE
doc: The need to stay with protobuf 3.25.x

### DIFF
--- a/backends/credhub/build.gradle
+++ b/backends/credhub/build.gradle
@@ -1,7 +1,4 @@
 buildscript {
-    ext {
-        grpcVersion = '1.62.2'
-    }
     repositories {
         mavenCentral()
         maven { url("https://repo.spring.io/plugins-release") }
@@ -128,6 +125,6 @@ asciidoctor.finalizedBy(buildAndCopyRestDocsIntoSpringStaticAssetLocation)
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.25.3"
+        artifact = "com.google.protobuf:protoc:${protoCVersion}"
     }
 }

--- a/backends/remote/build.gradle
+++ b/backends/remote/build.gradle
@@ -1,7 +1,4 @@
 buildscript {
-    ext {
-        grpcVersion = '1.62.2'
-    }
     repositories {
         mavenCentral()
         maven { url("https://repo.spring.io/plugins-release") }
@@ -99,7 +96,7 @@ sourceSets {
 assemble.mustRunAfter("clean")
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.25.3"
+        artifact = "com.google.protobuf:protoc:${protoCVersion}"
     }
     plugins {
         grpc {

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,15 @@ buildscript {
         springSecurityOauth2AutoconfigureVersion = '2.6.8'
         mariadbJdbcVersion = '2.7.12' // Bumping to v3 breaks some pipeline jobs, so pinning to v2 for now. v2 (current version) is stable and will be supported until about September 2025 (https://mariadb.com/kb/en/about-mariadb-connector-j/).
         snakeyamlVersion = '2.2'
+        grpcVersion = '1.62.2'
+        // We need to stay with protobuf-java & protoc 3.25.x as the latest
+        // grpc 1.62.2 still depends on protobuf-java & protoc 3.25.x. Once we
+        // bump grpc to version that depnds on protobuf-java & protoc to 4.x.x,
+        // it is likely that we are going to get conflicts because we also have
+        // direct dependency to protobuf 3.25.x. We will need to bump protobuf
+        // version to 4.x.x then.
+        protoBufJavaVersion = '3.25.3'
+        protoCVersion = '3.25.3'
     }
     repositories {
         mavenCentral()

--- a/components/credentials/build.gradle
+++ b/components/credentials/build.gradle
@@ -70,6 +70,12 @@ dependencies {
     implementation("org.apache.commons:commons-lang3:${apacheCommonsLang3Version}")
     implementation("org.apache.httpcomponents:httpclient:${apacheHttpClientVersion}")
     implementation("commons-codec:commons-codec:${commonsCodecVersion}")
+
+    // We need to stay with protobuf 3.25.x as the latest grpc 1.62.2 still
+    // depends on protobuf 3.25.x. Once we bump grpc to version that depnds on
+    // protobuf to 4.x.x, it is likely that we are going to get conflicts
+    // because we also have direct dependency to protobuf 3.25.x. We will need
+    // to bump protobuf version to 4.x.x then.
     implementation("com.google.protobuf:protobuf-java:3.25.3")
 }
 

--- a/components/credentials/build.gradle
+++ b/components/credentials/build.gradle
@@ -1,7 +1,4 @@
 buildscript {
-    ext {
-        grpcVersion = '1.62.2'
-    }
     repositories {
         mavenCentral()
         maven { url("https://repo.spring.io/plugins-release") }
@@ -70,13 +67,7 @@ dependencies {
     implementation("org.apache.commons:commons-lang3:${apacheCommonsLang3Version}")
     implementation("org.apache.httpcomponents:httpclient:${apacheHttpClientVersion}")
     implementation("commons-codec:commons-codec:${commonsCodecVersion}")
-
-    // We need to stay with protobuf 3.25.x as the latest grpc 1.62.2 still
-    // depends on protobuf 3.25.x. Once we bump grpc to version that depnds on
-    // protobuf to 4.x.x, it is likely that we are going to get conflicts
-    // because we also have direct dependency to protobuf 3.25.x. We will need
-    // to bump protobuf version to 4.x.x then.
-    implementation("com.google.protobuf:protobuf-java:3.25.3")
+    implementation("com.google.protobuf:protobuf-java:${protoBufJavaVersion}")
 }
 
 dependencyManagement {

--- a/components/encryption/build.gradle
+++ b/components/encryption/build.gradle
@@ -1,7 +1,4 @@
 buildscript {
-    ext {
-        grpcVersion = '1.62.2'
-    }
     repositories {
         mavenCentral()
         maven { url("https://repo.spring.io/plugins-release") }
@@ -106,7 +103,7 @@ sourceSets {
 assemble.mustRunAfter("clean")
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.25.3"
+        artifact = "com.google.protobuf:protoc:${protoCVersion}"
     }
     plugins {
         grpc {


### PR DESCRIPTION
Documenting instead of adding to dependabot ignore list. Will have to disregard 4.x `protobuf` dependabot PRs for a while, but the expectation is that `grpc` will be updated  to bump its dependency to `protobuf` in near future, hopefully.