### PR TITLE
fix: postgres script error

### DIFF
--- a/applications/credhub-api/src/main/resources/db/migration/postgres/V58__remove_triggers.sql
+++ b/applications/credhub-api/src/main/resources/db/migration/postgres/V58__remove_triggers.sql
@@ -1,9 +1,6 @@
+DROP TRIGGER IF EXISTS tr_credential_version_post_del ON credential_version;
 DROP FUNCTION IF EXISTS del_credential_version_encrypted_value();
 
-DROP TRIGGER IF EXISTS tr_credential_version_post_del ON credential_version;
-
-DROP FUNCTION IF EXISTS del_user_or_password_credential_encrypted_value();
-
 DROP TRIGGER IF EXISTS tr_password_credential_post_del ON password_credential;
-
 DROP TRIGGER IF EXISTS tr_user_credential_post_del ON user_credential;
+DROP FUNCTION IF EXISTS del_user_or_password_credential_encrypted_value();


### PR DESCRIPTION
- Fixed the drop operation order for the following error:
```
ERROR: cannot drop function del_credential_version_encrypted_value() because other objects depend on it
  Detail: trigger tr_credential_version_post_del on table credential_version depends on function del_credential_version_encrypted_value()
```