### PR TITLE
fix: CVE in `io.netty.netty-codec-http`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,10 @@ buildscript {
     // CVE-2024-22257. So, override that with spring-security 5.7 latest patch
     // version. This should be removed once spring-boot version is bumped.
     ext['spring-security.version'] = '5.7.12'
+
+    // spring-boot 2.7.18 has dependency to io.netty 4.1.101 which has
+    // CVE-2024-29025. So override it with the latest patch.
+    ext['netty.version'] = '4.1.108.Final'
 }
 
 plugins {


### PR DESCRIPTION
- Overrode spring-boot-managed `io.netty` dependency with latest patch version.

[#187358314]