### PR TITLE
187367323 dbs not allowing trigger creation

### DIFF
--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateVersionDeleteTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateVersionDeleteTest.java
@@ -1,5 +1,7 @@
 package org.cloudfoundry.credhub.integration;
 
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -13,6 +15,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import com.jayway.jsonpath.JsonPath;
 import org.cloudfoundry.credhub.CredhubTestApp;
+import org.cloudfoundry.credhub.data.EncryptedValueDataService;
 import org.cloudfoundry.credhub.helpers.RequestHelper;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
@@ -51,6 +54,9 @@ public class CertificateVersionDeleteTest {
   @Autowired
   private WebApplicationContext webApplicationContext;
 
+  @Autowired
+  EncryptedValueDataService encryptedValueDataService;
+
   private MockMvc mockMvc;
 
   @Rule
@@ -71,6 +77,9 @@ public class CertificateVersionDeleteTest {
 
   @Test
   public void deleteCertificateVersion_whenThereAreOtherVersionsOfTheCertificate_deletesTheSpecifiedVersion() throws Exception {
+    UUID aUuid = UUID.randomUUID();
+    var nEncrypredValuesPre = encryptedValueDataService.countAllByCanaryUuid(aUuid);
+
     final String credentialName = "/test-certificate";
 
     String response = generateCertificateCredential(mockMvc, credentialName, true, "test", null, ALL_PERMISSIONS_TOKEN);
@@ -81,13 +90,14 @@ public class CertificateVersionDeleteTest {
       .read("$.certificates[0].id");
 
     final String version = RequestHelper.regenerateCertificate(mockMvc, uuid, false, ALL_PERMISSIONS_TOKEN);
+    assertThat("One associated encrypted value exist for each certificate vesion",
+            encryptedValueDataService.countAllByCanaryUuid(aUuid), equalTo(nEncrypredValuesPre + 2));
+
     final String versionUuid = JsonPath.parse(version).read("$.id");
     final String versionValue = JsonPath.parse(version).read("$.value.certificate");
-
     final MockHttpServletRequestBuilder request = delete("/api/v1/certificates/" + uuid + "/versions/" + versionUuid)
       .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
       .accept(APPLICATION_JSON);
-
     response = mockMvc.perform(request)
       .andExpect(status().isOk())
       .andReturn().getResponse().getContentAsString();
@@ -103,6 +113,8 @@ public class CertificateVersionDeleteTest {
     final JSONArray jsonArray = new JSONArray(response);
     assertThat(jsonArray.length(), equalTo(1));
     assertThat(JsonPath.parse(jsonArray.get(0).toString()).read("$.value.certificate"), equalTo(nonDeletedVersion));
+    assertThat("Associated encrypted value is deleted when the certificate version is deleted",
+            encryptedValueDataService.countAllByCanaryUuid(aUuid), equalTo(nEncrypredValuesPre + 1));
   }
 
   @Test

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateVersionDeleteTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateVersionDeleteTest.java
@@ -78,7 +78,7 @@ public class CertificateVersionDeleteTest {
   @Test
   public void deleteCertificateVersion_whenThereAreOtherVersionsOfTheCertificate_deletesTheSpecifiedVersion() throws Exception {
     UUID aUuid = UUID.randomUUID();
-    var nEncrypredValuesPre = encryptedValueDataService.countAllByCanaryUuid(aUuid);
+    var nEncryptedValuesPre = encryptedValueDataService.countAllByCanaryUuid(aUuid);
 
     final String credentialName = "/test-certificate";
 
@@ -91,7 +91,7 @@ public class CertificateVersionDeleteTest {
 
     final String version = RequestHelper.regenerateCertificate(mockMvc, uuid, false, ALL_PERMISSIONS_TOKEN);
     assertThat("One associated encrypted value exist for each certificate vesion",
-            encryptedValueDataService.countAllByCanaryUuid(aUuid), equalTo(nEncrypredValuesPre + 2));
+            encryptedValueDataService.countAllByCanaryUuid(aUuid), equalTo(nEncryptedValuesPre + 2));
 
     final String versionUuid = JsonPath.parse(version).read("$.id");
     final String versionValue = JsonPath.parse(version).read("$.value.certificate");
@@ -114,7 +114,7 @@ public class CertificateVersionDeleteTest {
     assertThat(jsonArray.length(), equalTo(1));
     assertThat(JsonPath.parse(jsonArray.get(0).toString()).read("$.value.certificate"), equalTo(nonDeletedVersion));
     assertThat("Associated encrypted value is deleted when the certificate version is deleted",
-            encryptedValueDataService.countAllByCanaryUuid(aUuid), equalTo(nEncrypredValuesPre + 1));
+            encryptedValueDataService.countAllByCanaryUuid(aUuid), equalTo(nEncryptedValuesPre + 1));
   }
 
   @Test

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/Credential.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/Credential.kt
@@ -5,10 +5,13 @@ import org.cloudfoundry.credhub.audit.AuditableCredential
 import org.cloudfoundry.credhub.constants.UuidConstants.Companion.UUID_BYTES
 import org.hibernate.annotations.GenericGenerator
 import java.util.UUID
+import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.Id
+import javax.persistence.OneToMany
 import javax.persistence.Table
 
 @Entity
@@ -20,6 +23,11 @@ class Credential : AuditableCredential {
     @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     override var uuid: UUID? = null
+
+    @OneToMany(cascade = [CascadeType.REMOVE],
+        mappedBy = "credential", fetch = FetchType.EAGER)
+    var credentialVersions: MutableList<CredentialVersionData<*>> =
+        mutableListOf();
 
     @Column(nullable = false)
     override var name: String? = null

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/Credential.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/Credential.kt
@@ -24,10 +24,12 @@ class Credential : AuditableCredential {
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     override var uuid: UUID? = null
 
-    @OneToMany(cascade = [CascadeType.REMOVE],
-        mappedBy = "credential", fetch = FetchType.EAGER)
+    @OneToMany(
+        cascade = [CascadeType.REMOVE],
+        mappedBy = "credential", fetch = FetchType.EAGER
+    )
     var credentialVersions: MutableList<CredentialVersionData<*>> =
-        mutableListOf();
+        mutableListOf()
 
     @Column(nullable = false)
     override var name: String? = null

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/services/DefaultCredentialVersionDataServiceTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/services/DefaultCredentialVersionDataServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -281,6 +282,7 @@ public class DefaultCredentialVersionDataServiceTest {
   }
 
   @Test
+  @Transactional(propagation = Propagation.NEVER)
   public void delete_onACredentialName_deletesAllCredentialsWithTheName() {
     long nEncryptedValuesPre = encryptedValueRepository.count();
     final Credential credential = credentialDataService
@@ -317,6 +319,7 @@ public class DefaultCredentialVersionDataServiceTest {
   }
 
   @Test
+  @Transactional(propagation = Propagation.NEVER)
   public void delete_givenACredentialNameCasedDifferentlyFromTheActual_shouldBeCaseInsensitive() {
     long nEncryptedValuesPre = encryptedValueRepository.count();
     final Credential credentialName = credentialDataService
@@ -353,6 +356,7 @@ public class DefaultCredentialVersionDataServiceTest {
   }
 
   @Test
+  @Transactional(propagation = Propagation.NEVER)
   public void delete_UserTypeCredential() {
     long nEncryptedValuesPre = encryptedValueRepository.count();
     final Credential credentialName = credentialDataService.save(

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/services/DefaultCredentialVersionDataServiceTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/services/DefaultCredentialVersionDataServiceTest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.function.Consumer;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -31,11 +32,13 @@ import org.cloudfoundry.credhub.entity.Credential;
 import org.cloudfoundry.credhub.entity.CredentialVersionData;
 import org.cloudfoundry.credhub.entity.PasswordCredentialVersionData;
 import org.cloudfoundry.credhub.entity.SshCredentialVersionData;
+import org.cloudfoundry.credhub.entity.UserCredentialVersionData;
 import org.cloudfoundry.credhub.entity.ValueCredentialVersionData;
 import org.cloudfoundry.credhub.exceptions.MaximumSizeException;
 import org.cloudfoundry.credhub.exceptions.ParameterizedValidationException;
 import org.cloudfoundry.credhub.repositories.CredentialRepository;
 import org.cloudfoundry.credhub.repositories.CredentialVersionRepository;
+import org.cloudfoundry.credhub.repositories.EncryptedValueRepository;
 import org.cloudfoundry.credhub.util.CurrentTimeProvider;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.utils.DatabaseUtilities;
@@ -60,6 +63,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -70,11 +74,17 @@ import static org.junit.Assert.assertThat;
 @Transactional
 public class DefaultCredentialVersionDataServiceTest {
 
+  @Value("${spring.profiles.active}")
+  private String activeSpringProfile;
+
   @Autowired
   private CredentialVersionRepository credentialVersionRepository;
 
   @Autowired
   private CredentialRepository credentialRepository;
+
+  @Autowired
+  private EncryptedValueRepository encryptedValueRepository;
 
   @Autowired
   private EncryptionKeyCanaryDataService encryptionKeyCanaryDataService;
@@ -272,6 +282,7 @@ public class DefaultCredentialVersionDataServiceTest {
 
   @Test
   public void delete_onACredentialName_deletesAllCredentialsWithTheName() {
+    long nEncryptedValuesPre = encryptedValueRepository.count();
     final Credential credential = credentialDataService
       .save(new Credential("/my-credential"));
 
@@ -301,10 +312,13 @@ public class DefaultCredentialVersionDataServiceTest {
 
     assertThat(subject.findAllByName("/my-credential"), hasSize(0));
     assertNull(credentialDataService.find("/my-credential"));
+    assertEquals("Associated encryptedValues are deleted when password credential is deleted",
+            nEncryptedValuesPre, encryptedValueRepository.count());
   }
 
   @Test
   public void delete_givenACredentialNameCasedDifferentlyFromTheActual_shouldBeCaseInsensitive() {
+    long nEncryptedValuesPre = encryptedValueRepository.count();
     final Credential credentialName = credentialDataService
       .save(new Credential("/my-credential"));
 
@@ -334,6 +348,46 @@ public class DefaultCredentialVersionDataServiceTest {
     subject.delete("/MY-CREDENTIAL");
 
     assertThat(subject.findAllByName("/my-credential"), empty());
+    assertEquals("Associated encryptedValues are deleted when password credential is deleted",
+            nEncryptedValuesPre, encryptedValueRepository.count());
+  }
+
+  @Test
+  public void delete_UserTypeCredential() {
+    long nEncryptedValuesPre = encryptedValueRepository.count();
+    final Credential credentialName = credentialDataService.save(
+            new Credential("/my-credential"));
+
+    final EncryptedValue encryptedValueA = new EncryptedValue();
+    encryptedValueA.setEncryptionKeyUuid(activeCanaryUuid);
+    encryptedValueA.setEncryptedValue("credential-password".getBytes(UTF_8));
+    encryptedValueA.setNonce(new byte[]{});
+
+    final UserCredentialVersionData credentialDataA =
+            new UserCredentialVersionData("test-user");
+    credentialDataA.setCredential(credentialName);
+    credentialDataA.setEncryptedValueData(encryptedValueA);
+    credentialDataA.setSalt("salt");
+    subject.save(credentialDataA);
+
+    final EncryptedValue encryptedValueB = new EncryptedValue();
+    encryptedValueB.setEncryptionKeyUuid(activeCanaryUuid);
+    encryptedValueB.setEncryptedValue("another password".getBytes(UTF_8));
+    encryptedValueB.setNonce(new byte[]{});
+
+    final UserCredentialVersionData credentialDataB = new UserCredentialVersionData(
+            "/my-credential");
+    credentialDataB.setCredential(credentialName);
+    credentialDataB.setEncryptedValueData(encryptedValueB);
+    credentialDataB.setSalt("salt");
+    subject.save(credentialDataB);
+
+    assertThat(subject.findAllByName("/my-credential"), hasSize(2));
+
+    subject.delete("/my-credential");
+    assertThat(subject.findAllByName("/my-credential"), empty());
+    assertEquals("Associated encryptedValues are deleted when user credential is deleted",
+            nEncryptedValuesPre, encryptedValueRepository.count());
   }
 
   @Test


### PR DESCRIPTION
Re-implemented fix for https://github.com/cloudfoundry/credhub/issues/231 with JPA cascade-remove instead of database triggers. See commit messages for further details.