### PR TITLE
Revert "187367323 dbs not allowing trigger creation"

### DIFF
--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateVersionDeleteTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateVersionDeleteTest.java
@@ -78,7 +78,7 @@ public class CertificateVersionDeleteTest {
   @Test
   public void deleteCertificateVersion_whenThereAreOtherVersionsOfTheCertificate_deletesTheSpecifiedVersion() throws Exception {
     UUID aUuid = UUID.randomUUID();
-    var nEncryptedValuesPre = encryptedValueDataService.countAllByCanaryUuid(aUuid);
+    var nEncrypredValuesPre = encryptedValueDataService.countAllByCanaryUuid(aUuid);
 
     final String credentialName = "/test-certificate";
 
@@ -91,7 +91,7 @@ public class CertificateVersionDeleteTest {
 
     final String version = RequestHelper.regenerateCertificate(mockMvc, uuid, false, ALL_PERMISSIONS_TOKEN);
     assertThat("One associated encrypted value exist for each certificate vesion",
-            encryptedValueDataService.countAllByCanaryUuid(aUuid), equalTo(nEncryptedValuesPre + 2));
+            encryptedValueDataService.countAllByCanaryUuid(aUuid), equalTo(nEncrypredValuesPre + 2));
 
     final String versionUuid = JsonPath.parse(version).read("$.id");
     final String versionValue = JsonPath.parse(version).read("$.value.certificate");
@@ -114,7 +114,7 @@ public class CertificateVersionDeleteTest {
     assertThat(jsonArray.length(), equalTo(1));
     assertThat(JsonPath.parse(jsonArray.get(0).toString()).read("$.value.certificate"), equalTo(nonDeletedVersion));
     assertThat("Associated encrypted value is deleted when the certificate version is deleted",
-            encryptedValueDataService.countAllByCanaryUuid(aUuid), equalTo(nEncryptedValuesPre + 1));
+            encryptedValueDataService.countAllByCanaryUuid(aUuid), equalTo(nEncrypredValuesPre + 1));
   }
 
   @Test

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/Credential.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/Credential.kt
@@ -5,13 +5,10 @@ import org.cloudfoundry.credhub.audit.AuditableCredential
 import org.cloudfoundry.credhub.constants.UuidConstants.Companion.UUID_BYTES
 import org.hibernate.annotations.GenericGenerator
 import java.util.UUID
-import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
-import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.Id
-import javax.persistence.OneToMany
 import javax.persistence.Table
 
 @Entity
@@ -23,11 +20,6 @@ class Credential : AuditableCredential {
     @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     override var uuid: UUID? = null
-
-    @OneToMany(cascade = [CascadeType.REMOVE],
-        mappedBy = "credential", fetch = FetchType.EAGER)
-    var credentialVersions: MutableList<CredentialVersionData<*>> =
-        mutableListOf();
 
     @Column(nullable = false)
     override var name: String? = null

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/Credential.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/Credential.kt
@@ -24,12 +24,10 @@ class Credential : AuditableCredential {
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     override var uuid: UUID? = null
 
-    @OneToMany(
-        cascade = [CascadeType.REMOVE],
-        mappedBy = "credential", fetch = FetchType.EAGER
-    )
+    @OneToMany(cascade = [CascadeType.REMOVE],
+        mappedBy = "credential", fetch = FetchType.EAGER)
     var credentialVersions: MutableList<CredentialVersionData<*>> =
-        mutableListOf()
+        mutableListOf();
 
     @Column(nullable = false)
     override var name: String? = null

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/services/DefaultCredentialVersionDataServiceTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/services/DefaultCredentialVersionDataServiceTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -282,7 +281,6 @@ public class DefaultCredentialVersionDataServiceTest {
   }
 
   @Test
-  @Transactional(propagation = Propagation.NEVER)
   public void delete_onACredentialName_deletesAllCredentialsWithTheName() {
     long nEncryptedValuesPre = encryptedValueRepository.count();
     final Credential credential = credentialDataService
@@ -319,7 +317,6 @@ public class DefaultCredentialVersionDataServiceTest {
   }
 
   @Test
-  @Transactional(propagation = Propagation.NEVER)
   public void delete_givenACredentialNameCasedDifferentlyFromTheActual_shouldBeCaseInsensitive() {
     long nEncryptedValuesPre = encryptedValueRepository.count();
     final Credential credentialName = credentialDataService
@@ -356,7 +353,6 @@ public class DefaultCredentialVersionDataServiceTest {
   }
 
   @Test
-  @Transactional(propagation = Propagation.NEVER)
   public void delete_UserTypeCredential() {
     long nEncryptedValuesPre = encryptedValueRepository.count();
     final Credential credentialName = credentialDataService.save(


### PR DESCRIPTION
Reverts cloudfoundry/credhub#726.
There is a postgresql-only test that failed:

```
org.cloudfoundry.credhub.handlers.DefaultCertificatesHandlerIntegrationTest > handleGetAllRequest_65536Certs_doesNotCrash
...
Object [id=8df2048d-8be8-45e5-9ec8-874d8481499d] was not of the specified subclass [org.cloudfoundry.credhub.entity.CredentialVersionData] : Discriminator: foo; nested exception is org.hibernate.WrongClassException: Object [id=8df2048d-8be8-45e5-9ec8-874d8481499d] was not of the specified subclass [org.cloudfoundry.credhub.entity.CredentialVersionData] : Discriminator: foo
org.springframework.orm.ObjectRetrievalFailureException: Object [id=8df2048d-8be8-45e5-9ec8-874d8481499d] was not of the specified subclass [org.cloudfoundry.credhub.entity.CredentialVersionData] : Discriminator: foo; nested exception is org.hibernate.WrongClassException: Object [id=8df2048d-8be8-45e5-9ec8-874d8481499d] was not of the specified subclass [org.cloudfoundry.credhub.entity.CredentialVersionData] : Discriminator: foo
	at org.springframework.orm.jpa.vendor.HibernateJpaDialect.convertHibernateAccessException(HibernateJpaDialect.java:311)
	at org.springframework.orm.jpa.vendor.HibernateJpaDialect.translateExceptionIfPossible(HibernateJpaDialect.java:233)
```
I did not see this before merge because I was primarily testing with mysql.