### PR TITLE
doc: Update the CredHub version number that has the orphaned `encrypt…

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,6 @@ CREDENTIAL_ROOT=/path/to/credhub/repo/plus/src/test/resources ./scripts/run_test
 Assuming it works, that will generate some test client certificates for testing mutual TLS (in `certs/` in the acceptance test directory) and run the acceptance test suite against your locally running credhub server.
 
 ### Cleaning up orphaned encrypted_value records
-To clean up orphaned `encrypted_value` records from CredHub version 2.12.66 and
+To clean up orphaned `encrypted_value` records from CredHub version 2.12.70 and
 earlier (https://github.com/cloudfoundry/credhub/issues/231), follow the steps decribed in
 [Cleaning up orphaned encrypted_value records](docs/orphaned-encryption-value-cleanup.md).

--- a/docs/orphaned-encryption-value-cleanup.md
+++ b/docs/orphaned-encryption-value-cleanup.md
@@ -1,5 +1,5 @@
 ## Cleaning up orphaned encrypted_value records
-CredHub version 2.12.66 and earlier had a bug where `encrypted_value`
+CredHub version 2.12.70 and earlier had a bug where `encrypted_value`
 records were not deleted when the associated credentials were deleted.
 (See https://github.com/cloudfoundry/credhub/issues/231.)
 


### PR DESCRIPTION
…ed_value` data fix

- Because the latest fix is now in version 2.12.70.

[#187401693]