### PR TITLE
fix: DB migration fails with AWS RDS MySQL 5.7

### DIFF
--- a/applications/credhub-api/src/main/resources/db/migration/mysql/V58__remove_triggers.sql
+++ b/applications/credhub-api/src/main/resources/db/migration/mysql/V58__remove_triggers.sql
@@ -1,6 +1,0 @@
-
-DROP TRIGGER IF EXISTS tr_credential_version_pre_del;
-
-DROP TRIGGER IF EXISTS tr_credential_version_post_del;
-
-DROP TRIGGER IF EXISTS tr_credential_pre_del;


### PR DESCRIPTION
- issue: the "DROP TRIGGER" step of our MySQL DB migration fails when used with AWS RDS MySQL 5.7 due to:
```
(conn=127) You do not have the SUPER privilege and binary logging is enabled
```
- We decided that the best approach is to just remove this migration step, even though modifying past migrations is not recommended by flyway (but in the past, in our context removing migration steps have not created any problems).
- Note: This removal comes with a small problem where the triggers in question are not removed (because we do want these triggers to be removed, since they are not compatible with our latest code in terms of DB cleanup, see: https://github.com/cloudfoundry/credhub/pull/728). However, this problematic scenario should be quite narrow (only for users who have successfully installed CredHub 2.12.67, which adds the triggers, and have never upgraded to any versions between 2.12.69 and the latest current version (2.12.85 as of now), which contains the "DROP TRIGGER" step). For these users, we will publish docs on how to fix it (manually drop the triggers).

[#187774971]