### PR TITLE
backfill tests: case-insensitive cred search

### DIFF
--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialFindTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialFindTest.java
@@ -83,7 +83,7 @@ public class CredentialFindTest {
   }
 
   @Test
-  public void findCredentials_byNameLike_whenSearchTermContainsNoSlash_returnsCredentialMetadata() throws Exception {
+  public void findCredentials_byNameLike_caseInsensitively_whenSearchTermContainsNoSlash_returnsCredentialMetadata() throws Exception {
     generatePassword(mockMvc, credentialName, true, 20, ALL_PERMISSIONS_TOKEN);
     final ResultActions response = findCredentialsByNameLike(credentialName.substring(4).toUpperCase(),
             ALL_PERMISSIONS_TOKEN);

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialGetTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialGetTest.java
@@ -31,10 +31,13 @@ import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 
 import static org.cloudfoundry.credhub.helpers.RequestHelper.generateCertificateCredential;
+import static org.cloudfoundry.credhub.helpers.RequestHelper.generatePassword;
 import static org.cloudfoundry.credhub.helpers.RequestHelper.getCertificateCredentialsByName;
+import static org.cloudfoundry.credhub.helpers.RequestHelper.getCredential;
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -54,6 +57,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class CredentialGetTest {
 
   private MockMvc mockMvc;
+
+  private final String credentialName = "/my-namespace/subTree/credential-name";
 
   @Autowired
   private WebApplicationContext webApplicationContext;
@@ -103,6 +108,14 @@ public class CredentialGetTest {
     final JSONObject responseObject = new JSONObject(response);
 
     assertThat(responseObject.getJSONArray("data").length(), equalTo(3));
+  }
+
+  @Test
+  public void getCredentialByName_shouldBeCaseInsensitive() throws Exception {
+    generatePassword(mockMvc, credentialName, true, 20, ALL_PERMISSIONS_TOKEN);
+
+    final String response = getCredential(mockMvc, credentialName.toUpperCase(), ALL_PERMISSIONS_TOKEN);
+    assertThat(response, containsString(credentialName));
   }
 
 


### PR DESCRIPTION
- add test about get cred by name case-insensitively
- rename test about find cred by name-like to indicate it's about case-insensitivity (following the naming pattern of other similar existing tests)
- motivation: we are about to perform some DB query optimization in terms of how we do case-insensitive cred name search, so need to make sure we have clear test coverage on this area in:
  - get cred by name (added in this commit)
  - find cred by name-like (already covered, renamed in this commit to make clearer)
  - delete by name (already covered)

[internal tracking: https://vmw-jira.broadcom.net/browse/TPCF-26571]