### PR TITLE
fix: issue #813 by removing problematic mysql migration

### DIFF
--- a/applications/credhub-api/src/main/resources/db/migration/mysql/V58__index_lowercase_credential_name.sql
+++ b/applications/credhub-api/src/main/resources/db/migration/mysql/V58__index_lowercase_credential_name.sql
@@ -1,2 +1,0 @@
-CREATE INDEX credential_name_lowercase
-    ON credential(name_lowercase);


### PR DESCRIPTION
- mysql migration v58 failed flyway validation because there was a prior migration also numbered v58
(082fd5e91c68b9fb340184f8fb4548e661890b48) which had since been removed but nevertheless was recorded in flyway history for those users who have installed credhub versions containing the old v58, hence creating a conflict with the new v58. Hence, this commit removes the new v58 for now to fix the issue for those users.

- leaving v57 alone because there was never a v57 before, only v57_2, which flyway treats as distinct from v57. See code history here: https://github.com/cloudfoundry/credhub/commits/main/applications/credhub-api/src/main/resources/db/migration/mysql

- we will try to add back the index (in this removed v58) later in a safe way.

- also: leaving postgres & H2 migrations intact because there is not a problem there.


# Upgrade path testing result

## Start server at 10c7295 
(where v57.2 was applied)

Flyway history:
```
|             72 | 56      | change expiry date in certificate credential                                  | SQL  | V56__change_expiry_date_in_certificate_credential.sql                                  |  -969791477 | root         | 2024-11-12 03:32:07 |             80 |       1 |
|             73 | 57.2    | delete related encrypted value when credential is deleted                     | SQL  | V57_2__delete_related_encrypted_value_when_credential_is_deleted.sql                   | -1930144391 | root         | 2024-11-12 03:32:07 |             56 |       1 |
```

## Upgrade to b0dd9ef
(where v57.2 was deleted and the old v58 was applied)

Flyway history:
```
|             72 | 56      | change expiry date in certificate credential                                  | SQL    | V56__change_expiry_date_in_certificate_credential.sql                                  |  -969791477 | root         | 2024-11-12 03:32:07 |             80 |       1 |
|             73 | 57.2    | delete related encrypted value when credential is deleted                     | SQL    | V57_2__delete_related_encrypted_value_when_credential_is_deleted.sql                   | -1930144391 | root         | 2024-11-12 03:32:07 |             56 |       1 |
|             74 | 57.2    | delete related encrypted value when credential is deleted                     | DELETE | V57_2__delete_related_encrypted_value_when_credential_is_deleted.sql                   | -1930144391 | root         | 2024-11-12 03:36:08 |              0 |       1 |
|             75 | 58      | remove triggers                                                               | SQL    | V58__remove_triggers.sql                                                               | -1214956128 | root         | 2024-11-12 03:36:08 |             49 |       1 |
```

## Upgrade to 0f61935
(aka the commit on top of `main` branch prior to this PR)

Issue #813 is reproduced by this step. flyway history remains the same as the migration fails. 


# Upgrade to this PR
Everything works and the flyway history is as expected: 
- the old v58 is deleted.
- the new v57 is still applied.

Flyway history:
```
|             72 | 56      | change expiry date in certificate credential                                  | SQL    | V56__change_expiry_date_in_certificate_credential.sql                                  |  -969791477 | root         | 2024-11-12 03:32:07 |             80 |       1 |
|             73 | 57.2    | delete related encrypted value when credential is deleted                     | SQL    | V57_2__delete_related_encrypted_value_when_credential_is_deleted.sql                   | -1930144391 | root         | 2024-11-12 03:32:07 |             56 |       1 |
|             74 | 57.2    | delete related encrypted value when credential is deleted                     | DELETE | V57_2__delete_related_encrypted_value_when_credential_is_deleted.sql                   | -1930144391 | root         | 2024-11-12 03:36:08 |              0 |       1 |
|             75 | 58      | index lowercase credential name                                               | SQL    | V58__remove_triggers.sql                                                               |  1764759980 | root         | 2024-11-12 03:36:08 |             49 |       1 |
|             76 | 58      | index lowercase credential name                                               | DELETE | V58__remove_triggers.sql                                                               |  1764759980 | root         | 2024-11-12 03:42:19 |              0 |       1 |
|             77 | 57      | add lowercase credential name column                                          | SQL    | V57__add_lowercase_credential_name_column.sql                                          | -1606535744 | root         | 2024-11-12 03:42:19 |             73 |       1 |
```