### PR TITLE
feat: add back index on credential lowercase name

### DIFF
--- a/applications/credhub-api/src/main/resources/db/migration/mysql/V59__add_lowercase_credential_name_index.sql
+++ b/applications/credhub-api/src/main/resources/db/migration/mysql/V59__add_lowercase_credential_name_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX credential_name_lowercase_index ON credential(name_lowercase);


### PR DESCRIPTION
- context: the performance improvement brought by indexing (#803) was reverted (#815) due to migration error (issue #813) for some users. This commit brings back that index, but doing so safely to avoid issues like #813 (#813 happened to some users due to migration file numbering conflict, this commit uses a fresh migration number (v59) to avoid that).

- Unfortunately, for the users who happened to have installed credhub v2.12.94 successfully (aka did not encounter #813), their mysql DB would already have an index called
"credential_name_lowercase". So in order for the migration in this commit to work for both those who have installed credhub v2.12.94 and those who have not, this commit's migration instead creates the index under a different name: "credential_name_lowercase_index" (mysql does not support the "CREATE INDEX...IF NOT EXIST" syntax). This would create some DB inefficiency (due to the presence of two functionally identical indexes) for those who have installed credhub v2.12.94 (which we think is a smaller subset of users), but the system would still work and likely a net improvement compared to before due to the presence of indexing. And we would instruct these users to manually drop the old, duplicate index ("credential_name_lowercase").

# alternative options considered

1. Simply creating a new migration step that creates an identical index as before: `CREATE INDEX credential_name_lowercase ON credential(name_lowercase);` and instruct the subset of users who run into error running this migration due to duplicate index names to manually fix it by dropping the index first and restarting credhub. => I think this PR's approach is less disruptive because it does not cause downtime. 
2. Basically implementing the logic of "CREATE INDEX...IF NOT EXIST" ourselves by querying system table and conditionally creating the new index. => This approach is possible but seems more complex & risk-prone. 