### PR TITLE
New oauth2 when given valid issuer returns200

### DIFF
--- a/components/auth/src/main/java/org/cloudfoundry/credhub/config/AuthConfiguration.java
+++ b/components/auth/src/main/java/org/cloudfoundry/credhub/config/AuthConfiguration.java
@@ -27,7 +27,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -110,7 +109,7 @@ public class AuthConfiguration {
     }
 
     @Bean
-    public JwtDecoder jwtDecoder(
+    public NimbusJwtDecoder jwtDecoder(
             @Value("${security.oauth2.resource.jwt.key_value:#{null}}") String keyStr,
             @Autowired OAuth2IssuerService oAuth2IssuerService
     ) throws URISyntaxException, InvalidKeySpecException, NoSuchAlgorithmException {


### PR DESCRIPTION
fix: a test data overriding
    
- Spying `oAuth2IssuerService!!.getIssuer()` does not work with modified `AuthConfiguration` as `jwtDecoder` bean is created at the startup.
- Instead, to manipulate the issuerURI, just replace `jwtDecoder`'s `JwtValidator` to a desired one.
- Also changed `AuthConfiguration.jwtDecoder()` to return `NimbusJwtDecoder` so we don't have to downcast it in the test code.
