### PR TITLE
feat: Provide OAuth error info in response body.

### DIFF
--- a/components/auth/src/main/java/org/cloudfoundry/credhub/config/AuthConfiguration.java
+++ b/components/auth/src/main/java/org/cloudfoundry/credhub/config/AuthConfiguration.java
@@ -39,6 +39,7 @@ import org.cloudfoundry.credhub.auth.ActuatorPortFilter;
 import org.cloudfoundry.credhub.auth.OAuth2IssuerService;
 import org.cloudfoundry.credhub.auth.PreAuthenticationFailureFilter;
 import org.cloudfoundry.credhub.auth.X509AuthenticationProvider;
+import org.cloudfoundry.credhub.config.auth.OAuth2AuthenticationExceptionHandler;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
@@ -96,7 +97,11 @@ public class AuthConfiguration {
                                         )
                                 )
                 )
-                .oauth2ResourceServer((oauth2) -> oauth2.jwt(withDefaults()))
+                .oauth2ResourceServer(
+                        (oauth2) ->
+                                oauth2.authenticationEntryPoint(
+                                        new OAuth2AuthenticationExceptionHandler())
+                                        .jwt(withDefaults()))
                 .httpBasic().disable()
                 .csrf().disable()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);

--- a/components/auth/src/main/java/org/cloudfoundry/credhub/config/auth/OAuth2AuthenticationExceptionHandler.java
+++ b/components/auth/src/main/java/org/cloudfoundry/credhub/config/auth/OAuth2AuthenticationExceptionHandler.java
@@ -1,0 +1,46 @@
+package org.cloudfoundry.credhub.config.auth;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import com.nimbusds.jose.shaded.gson.JsonObject;
+
+/**
+ * Customized BearerTokenAuthenticationEntryPoint to fill the response body
+ * with json error data when an OAuth2AuthenticationException occurs.
+ */
+public class OAuth2AuthenticationExceptionHandler
+        implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException)
+            throws IOException {
+        BearerTokenAuthenticationEntryPoint btaep =
+                new BearerTokenAuthenticationEntryPoint();
+        btaep.commence(request, response, authException);
+
+        if (authException instanceof OAuth2AuthenticationException) {
+            OAuth2Error error = ((OAuth2AuthenticationException) authException)
+                    .getError();
+            response.setContentType("application/json");
+            var jsonObject = new JsonObject();
+            jsonObject.addProperty("error", error.getErrorCode());
+            jsonObject.addProperty("error_description", error.getDescription());
+            try (PrintWriter writer = response.getWriter()) {
+                writer.write(jsonObject.toString());
+                writer.flush();
+            }
+        }
+    }
+}

--- a/components/auth/src/main/java/org/cloudfoundry/credhub/config/auth/OAuth2AuthenticationExceptionHandler.java
+++ b/components/auth/src/main/java/org/cloudfoundry/credhub/config/auth/OAuth2AuthenticationExceptionHandler.java
@@ -20,14 +20,14 @@ import com.nimbusds.jose.shaded.gson.JsonObject;
  */
 public class OAuth2AuthenticationExceptionHandler
         implements AuthenticationEntryPoint {
+    private BearerTokenAuthenticationEntryPoint btaep =
+            new BearerTokenAuthenticationEntryPoint();
 
     @Override
     public void commence(HttpServletRequest request,
                          HttpServletResponse response,
                          AuthenticationException authException)
             throws IOException {
-        BearerTokenAuthenticationEntryPoint btaep =
-                new BearerTokenAuthenticationEntryPoint();
         btaep.commence(request, response, authException);
 
         if (authException instanceof OAuth2AuthenticationException) {

--- a/components/auth/src/test/kotlin/org/cloudfoundry/credhub/auth/OAuth2ExtraValidationFilterTest.kt
+++ b/components/auth/src/test/kotlin/org/cloudfoundry/credhub/auth/OAuth2ExtraValidationFilterTest.kt
@@ -20,6 +20,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes
 import org.springframework.security.oauth2.jwt.JwtValidators
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers
@@ -28,6 +29,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
@@ -97,8 +99,7 @@ class OAuth2ExtraValidationFilterTest {
         this.mockMvc!!
             .perform(request)
             .andExpect(status().isUnauthorized)
-// TODO: Consider if needed
-//            .andExpect(jsonPath("$.error_description").value(ERROR_MESSAGE))
+            .andExpect(jsonPath("$.error").value(OAuth2ErrorCodes.INVALID_TOKEN))
     }
 
     @Test
@@ -114,21 +115,10 @@ class OAuth2ExtraValidationFilterTest {
             this.mockMvc!!
                 .perform(request)
                 .andExpect(status().isUnauthorized)
-// TODO: Consider if needed
-//                .andExpect(jsonPath("$.error_description").value(ERROR_MESSAGE))
+                .andExpect(jsonPath("$.error").value(OAuth2ErrorCodes.INVALID_TOKEN))
                 .andReturn()
                 .response
                 .contentAsString
-
-        // The response originally concatenated the error and the credential.
-        val expectedResponse =
-            "{\"error\":\"invalid_token\"," +
-                "\"error_description\":\"The request token identity zone does" +
-                " not match the UAA server authorized by CredHub. Please " +
-                "validate that your request token was issued by the UAA server" +
-                " authorized by CredHub and retry your request.\"}"
-
-//        assertThat(response, equalTo(expectedResponse))
         assertThat(spyController!!.getDataCount, equalTo(0))
     }
 
@@ -145,27 +135,10 @@ class OAuth2ExtraValidationFilterTest {
             this.mockMvc!!
                 .perform(request)
                 .andExpect(status().isUnauthorized)
-// TODO: Consider if needed
-//                .andExpect(
-//                    jsonPath(
-//                        "$.error_description",
-//                    ).value(
-//                        "The request token is malformed. Please validate that your request token was issued by the UAA server authorized by CredHub.",
-//                    ),
-//                )
+                .andExpect(jsonPath("$.error").value(OAuth2ErrorCodes.INVALID_TOKEN))
                 .andReturn()
                 .response
                 .contentAsString
-
-        // The response originally concatenated the error and the credential.
-// TODO: Consider if needed
-//        val expectedResponse =
-//            "{\"error\":\"invalid_token\"," +
-//                "\"error_description\":\"The request token is malformed. " +
-//                "Please validate that your request token was issued by the" +
-//                " UAA server authorized by CredHub.\"}"
-//
-//        assertThat(response, equalTo(expectedResponse))
         assertThat(spyController!!.getDataCount, equalTo(0))
     }
 
@@ -182,26 +155,10 @@ class OAuth2ExtraValidationFilterTest {
             this.mockMvc!!
                 .perform(request)
                 .andExpect(status().isUnauthorized)
-// TODO: Consider if needed
-//                .andExpect(
-//                    jsonPath(
-//                        "$.error_description",
-//                    ).value(
-//                        "The request token signature could not be verified. Please validate that your request token was issued by the UAA server authorized by CredHub.",
-//                    ),
-//                )
+                .andExpect(jsonPath("$.error").value(OAuth2ErrorCodes.INVALID_TOKEN))
                 .andReturn()
                 .response
                 .contentAsString
-
-        // The response originally concatenated the error and the credential.
-        val expectedResponse =
-            "{\"error\":\"invalid_token\",\"" +
-                "error_description\":\"The request token signature could not be" +
-                " verified. Please validate that your request token was issued" +
-                " by the UAA server authorized by CredHub.\"}"
-
-//        assertThat(response, equalTo(expectedResponse))
         assertThat(spyController!!.getDataCount, equalTo(0))
     }
 
@@ -215,8 +172,7 @@ class OAuth2ExtraValidationFilterTest {
                     .accept(APPLICATION_JSON)
                     .contentType(APPLICATION_JSON),
             ).andExpect(status().isUnauthorized)
-// TODO: Consider if needed
-//            .andExpect(jsonPath("$.error_description").value(ERROR_MESSAGE))
+            .andExpect(jsonPath("$.error").value(OAuth2ErrorCodes.INVALID_TOKEN))
     }
 
     @Test
@@ -229,8 +185,7 @@ class OAuth2ExtraValidationFilterTest {
                     .accept(APPLICATION_JSON)
                     .contentType(APPLICATION_JSON),
             ).andExpect(status().isUnauthorized)
-// TODO: Consider if needed
-//            .andExpect(jsonPath("$.error_description").value(ERROR_MESSAGE))
+            .andExpect(jsonPath("$.error").value(OAuth2ErrorCodes.INVALID_TOKEN))
     }
 
     @Test
@@ -244,8 +199,7 @@ class OAuth2ExtraValidationFilterTest {
                     .accept(APPLICATION_JSON)
                     .contentType(APPLICATION_JSON),
             ).andExpect(status().isUnauthorized)
-// TODO: Consider if needed
-//            .andExpect(jsonPath("$.error_description").value(EXPIRED_TOKEN_MESSAGE))
+            .andExpect(jsonPath("$.error").value(OAuth2ErrorCodes.INVALID_TOKEN))
     }
 
     @RestController
@@ -258,15 +212,5 @@ class OAuth2ExtraValidationFilterTest {
                 getDataCount += 1
                 return "some data"
             }
-    }
-
-    companion object {
-        private const val ERROR_MESSAGE =
-            "The request token identity zone does not match the UAA server" +
-                " authorized by CredHub. Please validate that your request" +
-                " token was issued by the UAA server authorized by CredHub" +
-                " and retry your request."
-
-        private const val EXPIRED_TOKEN_MESSAGE = "Access token expired"
     }
 }


### PR DESCRIPTION
- As we did in the existing credhub implemenmtation.
- However, instead of providing customized `error_description` string as we did in the existing credhub implementation, provide the `error_description` from `spring-security`, i.e. the same ones that are provided in the response header.
- It is because, unlikely the existing credhub implementation, we cannot tell exact kind of error based on the cause exceptions. For example, invalid issuer and expired token have the same cause exception but with specific error messages.

Making it as Draft PR for now, as I want to perform additional tasks as follows:
- Test with credhub-cli.
- Take another look at the option to provide customized `error_description` string as we did in the existing credhub implementation. I did spent quite some time on this already but ...