### PR TITLE
build(deps): Bump Java version from 17 to 21 (LTS)

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'liberica'
-          java-version: '17'
+          java-version: '21'
       - name: Build and test with Gradle
         run: ./gradlew clean build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM bellsoft/liberica-openjdk-debian:17 AS build
+FROM bellsoft/liberica-openjdk-debian:21 AS build
 WORKDIR /app
 COPY . /app
 RUN ./gradlew bootJar -x test -x check
 
-FROM bellsoft/liberica-openjre-debian:17 AS run
+FROM bellsoft/liberica-openjre-debian:21 AS run
 WORKDIR /app
 COPY \
   --from=build \

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ buildscript {
         mariadbJdbcVersion = '2.7.12' // Bumping to v3 breaks some pipeline jobs, so pinning to v2 for now. v2 (current version) is stable and will be supported until about September 2025 (https://mariadb.com/kb/en/about-mariadb-connector-j/).
         snakeyamlVersion = '2.4'
         grpcVersion = '1.71.0'
+        byteBuddyVersion = '1.14.12'
         // We need to stay with protobuf-java & protoc 3.25.x as the latest
         // grpc still depends on protobuf-java & protoc 3.25.x. Once we
         // bump grpc to version that depnds on protobuf-java & protoc to 4.x.x,
@@ -92,7 +93,9 @@ subprojects {
             implementation("org.yaml:snakeyaml:${snakeyamlVersion}")
             implementation("com.h2database:h2:${h2Version}")
             implementation("com.google.guava:guava:${guavaVersion}")
+            implementation("net.bytebuddy:byte-buddy:${byteBuddyVersion}")
             testImplementation("org.mockito:mockito-inline")
+            testImplementation("net.bytebuddy:byte-buddy-agent:${byteBuddyVersion}")
         }
     }
 }
@@ -100,4 +103,4 @@ subprojects {
 // Override spring boot's kotllin version dependency
 ext['kotlin.version'] = '${kotlinVersion}'
 
-assert JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)
+assert JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)


### PR DESCRIPTION
Due to issue described in: [issue](https://github.com/cloudfoundry/credhub/issues/872)