### PR TITLE
bump: Tomcat 9 to latest patch 9.0.102

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ buildscript {
 
     // spring-boot 2.7.18 has dependency to tomcat-embed-core 9.0.83, which
     // has multipe CVEs including CVE-2024-34750. So set it to latest 9.0.x.
-    ext["tomcat.version"] = '9.0.100'
+    ext["tomcat.version"] = '9.0.102'
 }
 
 plugins {


### PR DESCRIPTION
- This also fixes https://github.com/cloudfoundry/credhub/issues/872, which was caused by a changed made in Tomcat 9.0.100.