### PR TITLE
Custom jwt timestamp validator

### DIFF
--- a/components/auth/src/main/java/org/cloudfoundry/credhub/auth/CredHubJwtTimeValidator.java
+++ b/components/auth/src/main/java/org/cloudfoundry/credhub/auth/CredHubJwtTimeValidator.java
@@ -1,0 +1,65 @@
+package org.cloudfoundry.credhub.auth;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.util.Assert;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Custom implementation of
+ * {@link org.springframework.security.oauth2.jwt.JwtTimestampValidator}
+ * to override OAuth2Error creation for expired access token
+ */
+public class CredHubJwtTimeValidator implements OAuth2TokenValidator<Jwt> {
+    public static final String ACCESS_TOKEN_EXPIRED = "access_token_expired";
+    private final Log logger = LogFactory.getLog(getClass());
+    private static final Duration DEFAULT_MAX_CLOCK_SKEW = Duration.of(
+            60, ChronoUnit.SECONDS);
+    private final Duration clockSkew;
+    private Clock clock = Clock.systemUTC();
+
+    public CredHubJwtTimeValidator() {
+        this.clockSkew = DEFAULT_MAX_CLOCK_SKEW;
+    }
+
+    @Override
+    public OAuth2TokenValidatorResult validate(Jwt jwt) {
+        Assert.notNull(jwt, "jwt cannot be null");
+        Instant expiry = jwt.getExpiresAt();
+        if (expiry != null) {
+            if (Instant.now(this.clock).minus(this.clockSkew).isAfter(expiry)) {
+                OAuth2Error oAuth2Error = createOAuth2Error(
+                        ACCESS_TOKEN_EXPIRED, "Access token expired");
+                throw new OAuth2AuthenticationException(oAuth2Error);
+            }
+        }
+        Instant notBefore = jwt.getNotBefore();
+        if (notBefore != null) {
+            if (Instant.now(this.clock).plus(this.clockSkew)
+                    .isBefore(notBefore)) {
+                OAuth2Error oAuth2Error = createOAuth2Error(
+                        OAuth2ErrorCodes.INVALID_TOKEN,
+                        String.format("Jwt used before %s",
+                                jwt.getNotBefore()));
+                return OAuth2TokenValidatorResult.failure(oAuth2Error);
+            }
+        }
+        return OAuth2TokenValidatorResult.success();
+    }
+
+    private OAuth2Error createOAuth2Error(String code, String reason) {
+        this.logger.debug(reason);
+        return new OAuth2Error(code, reason, null);
+    }
+}

--- a/components/auth/src/main/java/org/cloudfoundry/credhub/auth/OAuth2AuthenticationExceptionHandler.java
+++ b/components/auth/src/main/java/org/cloudfoundry/credhub/auth/OAuth2AuthenticationExceptionHandler.java
@@ -1,4 +1,4 @@
-package org.cloudfoundry.credhub.config.auth;
+package org.cloudfoundry.credhub.auth;
 
 import java.io.IOException;
 import java.io.PrintWriter;

--- a/components/auth/src/main/java/org/cloudfoundry/credhub/config/AuthConfiguration.java
+++ b/components/auth/src/main/java/org/cloudfoundry/credhub/config/AuthConfiguration.java
@@ -36,10 +36,10 @@ import org.springframework.security.web.authentication.preauth.x509.X509Authenti
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.cloudfoundry.credhub.auth.ActuatorPortFilter;
+import org.cloudfoundry.credhub.auth.OAuth2AuthenticationExceptionHandler;
 import org.cloudfoundry.credhub.auth.OAuth2IssuerService;
 import org.cloudfoundry.credhub.auth.PreAuthenticationFailureFilter;
 import org.cloudfoundry.credhub.auth.X509AuthenticationProvider;
-import org.cloudfoundry.credhub.config.auth.OAuth2AuthenticationExceptionHandler;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 

--- a/components/auth/src/test/java/org/cloudfoundry/credhub/auth/OAuth2AuthenticationExceptionHandlerTest.java
+++ b/components/auth/src/test/java/org/cloudfoundry/credhub/auth/OAuth2AuthenticationExceptionHandlerTest.java
@@ -1,4 +1,4 @@
-package org.cloudfoundry.credhub.config.auth;
+package org.cloudfoundry.credhub.auth;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;

--- a/components/auth/src/test/kotlin/org/cloudfoundry/credhub/auth/OAuth2ExtraValidationFilterTest.kt
+++ b/components/auth/src/test/kotlin/org/cloudfoundry/credhub/auth/OAuth2ExtraValidationFilterTest.kt
@@ -199,7 +199,7 @@ class OAuth2ExtraValidationFilterTest {
                     .accept(APPLICATION_JSON)
                     .contentType(APPLICATION_JSON),
             ).andExpect(status().isUnauthorized)
-            .andExpect(jsonPath("$.error").value(OAuth2ErrorCodes.INVALID_TOKEN))
+            .andExpect(jsonPath("$.error").value(CredHubJwtTimeValidator.ACCESS_TOKEN_EXPIRED))
     }
 
     @RestController


### PR DESCRIPTION
fix: response error for expired access token
    
- Recent change of the error code was not compatible with `credhub-cli`, which is expecting a specific error code for expired access token.
- That apparently affected concourse use case.
- Modified the error code and description of the response for expired access token to match credhub 2.12.x implementation.
