### PR TITLE
fix: various unit test failures due to InvalidDataAccessResourceUsage…

### DIFF
--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/repositories/CredentialVersionRepository.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/repositories/CredentialVersionRepository.kt
@@ -1,5 +1,6 @@
 package org.cloudfoundry.credhub.repositories
 
+import org.cloudfoundry.credhub.entity.CertificateCredentialVersionData
 import org.cloudfoundry.credhub.entity.CredentialVersionData
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -33,7 +34,7 @@ interface CredentialVersionRepository : JpaRepository<CredentialVersionData<*>?,
                 "limit 1",
         nativeQuery = true,
     )
-    fun findLatestNonTransitionalCertificateVersion(credentialUUID: UUID?): CredentialVersionData<*>?
+    fun findLatestNonTransitionalCertificateVersion(credentialUUID: UUID?): CertificateCredentialVersionData?
 
     @Query(
         value =
@@ -45,7 +46,7 @@ interface CredentialVersionRepository : JpaRepository<CredentialVersionData<*>?,
                 "limit 1",
         nativeQuery = true,
     )
-    fun findTransitionalCertificateVersion(credentialUUID: UUID?): CredentialVersionData<*>?
+    fun findTransitionalCertificateVersion(credentialUUID: UUID?): CertificateCredentialVersionData?
 
     @Query(
         value =
@@ -57,7 +58,7 @@ interface CredentialVersionRepository : JpaRepository<CredentialVersionData<*>?,
                 "order by version_created_at limit 1000 offset ?1",
         nativeQuery = true,
     )
-    fun findUpTo1000VersionsWithNullCertificateMetadata(offset: Int): List<CredentialVersionData<*>?>
+    fun findUpTo1000VersionsWithNullCertificateMetadata(offset: Int): List<CertificateCredentialVersionData?>
 
     @Query(
         value =

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/services/DefaultCertificateVersionDataServiceTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/services/DefaultCertificateVersionDataServiceTest.java
@@ -64,7 +64,7 @@ public class DefaultCertificateVersionDataServiceTest {
   public void findByCredentialUUID_ReturnsLatestNonTransitionalVersion_WhenThereAreTransitionalAndNonTransitionalVersions() {
     final UUID uuid = UUID.randomUUID();
     final String uuidString = uuid.toString();
-    final CredentialVersionData certificateEntity = mock(CredentialVersionData.class);
+    final CertificateCredentialVersionData certificateEntity = mock(CertificateCredentialVersionData.class);
     final CertificateCredentialVersion certificateCredentialVersion = mock(CertificateCredentialVersion.class);
 
     when(versionRepository.findLatestNonTransitionalCertificateVersion(uuid)).thenReturn(certificateEntity);
@@ -80,7 +80,7 @@ public class DefaultCertificateVersionDataServiceTest {
   public void findByCredentialUUID_ReturnsLatestTransitionalVersion_WhenThereAreOnlyTransitionalVersions() {
     final UUID uuid = UUID.randomUUID();
     final String uuidString = uuid.toString();
-    final CredentialVersionData certificateEntity = mock(CredentialVersionData.class);
+    final CertificateCredentialVersionData certificateEntity = mock(CertificateCredentialVersionData.class);
     final CertificateCredentialVersion certificateCredentialVersion = mock(CertificateCredentialVersion.class);
 
     when(versionRepository.findLatestNonTransitionalCertificateVersion(uuid)).thenReturn(null);
@@ -98,7 +98,7 @@ public class DefaultCertificateVersionDataServiceTest {
     final Credential certificate = mock(Credential.class);
 
     when(dataService.find("/some-ca-name")).thenReturn(certificate);
-    final CredentialVersionData certificateEntity = mock(CredentialVersionData.class);
+    final CertificateCredentialVersionData certificateEntity = mock(CertificateCredentialVersionData.class);
     when(versionRepository.findLatestNonTransitionalCertificateVersion(any())).thenReturn(certificateEntity);
 
     final CredentialVersion expectedVersion = mock(CredentialVersion.class);
@@ -115,10 +115,10 @@ public class DefaultCertificateVersionDataServiceTest {
 
     when(dataService.find("/some-cert-name")).thenReturn(certificate);
 
-    final CredentialVersionData activeCert = mock(CredentialVersionData.class);
+    final CertificateCredentialVersionData activeCert = mock(CertificateCredentialVersionData.class);
     when(versionRepository.findLatestNonTransitionalCertificateVersion(any())).thenReturn(activeCert);
 
-    final CredentialVersionData transitionalCert = mock(CredentialVersionData.class);
+    final CertificateCredentialVersionData transitionalCert = mock(CertificateCredentialVersionData.class);
     when(versionRepository.findTransitionalCertificateVersion(any())).thenReturn(transitionalCert);
 
     final CredentialVersion expectedActive = mock(CredentialVersion.class);


### PR DESCRIPTION
…Exception

- after bumping to spring boot 3 (which also bumps hibernate to 6.6.x)
- error:
```
org.springframework.dao.InvalidDataAccessResourceUsageException: Unable to find column position by name: password_parameters_uuid [No such column: 'password_parameters_uuid'.
```
in `DefaultCredentialVersionDataServiceTest` and `CertificateMigrationTest`. This is confusing because for the data (certificate credentials) we are trying to access in this use case, we don't actually need `password_parameters_uuid` (only needed for password credentials).
- analysis:
  - in reality, column `password_parameters_uuid` is in table `password_credential` which becomes, along with data from some other tables, the specific entity `CredentialVersionData<PasswordCredentialVersionData>` (see code: https://github.com/cloudfoundry/credhub/blob/5f22e43bedd3f73623367c3e863a16294e9cff49/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/PasswordCredentialVersionData.kt#L23).
  - the query functions in `CredentialVersionRepository` (changed in this commit) used to return `CredentialVersionData<*>`, which is not specific enough, potentially confusing Hibernate into confusing it with / lumping it with `CredentialVersionData<PasswordCredentialVersionData>`.
  - In reality, the specific type required here is `CertificateCredentialVersionData` (which is a `CredentialVersionData<*>` but is more specific) which does not need `password_parameters_uuid`.
  - hence, change the return type into the more specific type, so Hibernate can be sure that we don't need `password_parameters_uuid` column.

[https://vmw-jira.broadcom.net/browse/TNZ-41345]