### PR TITLE
fix: `CretificateView.isTranstional` property name in json response

### DIFF
--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CertificateView.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CertificateView.kt
@@ -2,6 +2,7 @@ package org.cloudfoundry.credhub.views
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
 import org.cloudfoundry.credhub.credential.CredentialValue
 import org.cloudfoundry.credhub.domain.CertificateCredentialVersion
 import java.time.Instant
@@ -50,6 +51,7 @@ open class CertificateView : CredentialView {
             super.value = value
         }
 
+    @get:JsonProperty("transitional")
     val isTransitional: Boolean
         get() = version!!.isVersionTransitional
 


### PR DESCRIPTION
- Used to be `transitional` but is `is_transitional` with the newer version of jackson.
- For backward compatibility with credhub-cli, etc., overrode the property name to be the same as existing credhub version.