### PR TITLE
temp fix: pin hibernate to 6.5.x to avoid test failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,5 +76,9 @@ subprojects {
 
 // Override spring boot's kotllin version dependency
 ext['kotlin.version'] = '${kotlinVersion}'
+// Override spring boot's hibernate version dependency
+// This is because in hibernate 6.6.x+, CredentialAclEnforcementTest.DELETE_whenTheUserHasPermissionToDeleteTheCredential_succeeds (https://github.com/cloudfoundry/credhub/blob/5f22e43bedd3f73623367c3e863a16294e9cff49/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialAclEnforcementTest.java#L224)
+// fails due to "org.hibernate.TransientObjectException". Hence, temporarily pin hiberate back to 6.5.3.Final to unblock a credhub release with spring boot 3.
+ext['hibernate.version'] = '6.5.3.Final'
 
 assert JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)


### PR DESCRIPTION
- Override spring boot's hibernate version dependency to 6.5.x
- This is because in hibernate 6.6.x+, CredentialAclEnforcementTest.DELETE_whenTheUserHasPermissionToDeleteTheCredential_succeeds (https://github.com/cloudfoundry/credhub/blob/5f22e43bedd3f73623367c3e863a16294e9cff49/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialAclEnforcementTest.java#L224) fails due to "org.hibernate.TransientObjectException".
- Hence, temporarily pin hiberate back to 6.5.3.Final to unblock a credhub release with spring boot 3.

- additional notes about the TransientObjectException hibernate error:
  - it cannot be reproduced in real life with a running server
  - it happens in test whenever we generate a cred `foo`, deletes it, and then perform any other operation (even unrelated to the cred `foo`)
    - e.g. if you add any operation after [this delete step](https://github.com/cloudfoundry/credhub/blob/5f22e43bedd3f73623367c3e863a16294e9cff49/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialDeleteTest.java#L122), you'll see the same error.
  - possibly related to:
    - https://discourse.hibernate.org/t/instance-save-transient-before/10293
    - https://hibernate.atlassian.net/browse/HHH-18936

[https://vmw-jira.broadcom.net/browse/TNZ-41753]

# note
- even with this pinning; the overall effect of `boot3` branch is still a bump of Hibernate (currently credhub `main` is on hibernate 5.x.x, which is 1.5 years older than 6.5.x), just not to the latest.