### PR TITLE
fix: failure to get certs when request path has a trailing slash

### DIFF
--- a/backends/shared-backend-configuration/src/main/kotlin/org/cloudfoundry/credhub/config/WebMvcConfiguration.kt
+++ b/backends/shared-backend-configuration/src/main/kotlin/org/cloudfoundry/credhub/config/WebMvcConfiguration.kt
@@ -24,6 +24,7 @@ class WebMvcConfiguration
 
         override fun configurePathMatch(configurer: PathMatchConfigurer) {
             configurer.setUseSuffixPatternMatch(false)
+            configurer.setUseTrailingSlashMatch(true)
         }
 
         override fun addInterceptors(registry: InterceptorRegistry) {


### PR DESCRIPTION
- after bumping to spring boot 3
- error:
```
credhub curl -p /api/v1/certificates/
An application error occurred. Please contact your CredHub administrator.
```
when `credhub curl -p /api/v1/certificates` works
- To maintain backward compatibility, especially given that our acceptance test as well as some cli code (e.g.: https://github.com/cloudfoundry/credhub-cli/blob/11f3a43db498ee7f2adb8e19afcf3b1781d6e6ff/credhub/certificates.go#L32) still includes the trailing slash, we should maintain the old behavior when there is a trailing slash
- reference: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes
  - this `setUseTrailingSlashMatch` method in the guide is marked as deprecated, but so is many other methods used in our current `WebMvcConfiguration` class; let's use this approach and deal with all these deprecated things together later.

[https://vmw-jira.broadcom.net/browse/TNZ-41037]