### PR TITLE
Various dependency refactors and organization

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,18 +8,8 @@ updates:
   target-branch: main
   open-pull-requests-limit: 100
   ignore:
-  - dependency-name: "org.flywaydb:flyway-core" # Stay with 10.20.1 for now. Consider unpinning after spring-boot 3 migration.
-    update-types: [ "version-update:semver-major" ]
-  - dependency-name: "com.h2database:h2"                    ## can only bump to the next major (v2) after flyway is bumped to v8, see context: https://github.com/cloudfoundry/credhub/pull/259#issuecomment-1093414459
-    update-types: [ "version-update:semver-major" ]
   - dependency-name: "org.mariadb.jdbc:mariadb-java-client" ## version 3.0.3 of the driver drops support for Aurora - https://www.pivotaltracker.com/n/projects/2482247/stories/183282618
     update-types: ["version-update:semver-major"]
-  - dependency-name: "org.springframework.restdocs:spring-restdocs-mockmvc"  ## 3.0.0 bumps to Spring Framework 6.0.0 which requires Java 17. Bumps this after we take a Spring Boot version for the rest of the project that bumps to Spring Framework 6.0.0.
-    update-types: ["version-update:semver-major"]
-  - dependency-name: "org.springframework.restdocs:spring-restdocs-asciidoctor"  ## 3.0.0 bumps to Spring Framework 6.0.0 which requires Java 17. Bumps this after we take a Spring Boot version for the rest of the project that bumps to Spring Framework 6.0.0.
-    update-types: ["version-update:semver-major"]
-  - dependency-name: "org.springframework.boot:*"
-    update-types: [ "version-update:semver-major" ] # Bump this after we bump to Java 17, which v3 requires (and the current v2 will be supported until November 2023: https://spring.io/blog/2022/05/24/preparing-for-spring-boot-3-0)
   - dependency-name: "com.google.protobuf:protoc"
     update-types: [ "version-update:semver-major" ] # We need to stay with protobuf-java & protoc 3.25.x as the latest grpc still depends on protobuf-java & protoc 3.25.x https://github.com/grpc/grpc-java/issues/11015
   - dependency-name: "com.google.protobuf:protobuf-java"

--- a/applications/credhub-api/build.gradle
+++ b/applications/credhub-api/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation("org.flywaydb:flyway-core:${flywayVersion}")
     implementation("org.flywaydb:flyway-mysql:${flywayVersion}")
     implementation("org.flywaydb:flyway-database-postgresql:${flywayVersion}")
-    implementation("com.h2database:h2:${h2Version}")
+    implementation("com.h2database:h2")
 
     api("org.bouncycastle:bc-fips:${bcFipsVersion}")
     api("org.bouncycastle:bcpkix-fips:${bcpkixFipsVersion}")

--- a/backends/credhub/build.gradle
+++ b/backends/credhub/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation("org.flywaydb:flyway-mysql:${flywayVersion}")
     implementation("org.flywaydb:flyway-database-postgresql:${flywayVersion}")
     implementation("org.mariadb.jdbc:mariadb-java-client:${mariadbJdbcVersion}")
-    implementation("com.h2database:h2:${h2Version}")
+    implementation("com.h2database:h2")
 
     // Other
     api("org.bouncycastle:bc-fips:${bcFipsVersion}")

--- a/backends/shared-backend-configuration/build.gradle
+++ b/backends/shared-backend-configuration/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
-    implementation("commons-codec:commons-codec:${commonsCodecVersion}")
+    implementation("commons-codec:commons-codec")
 
     // DB
     implementation("org.flywaydb:flyway-core:${flywayVersion}")

--- a/backends/shared-backend-configuration/build.gradle
+++ b/backends/shared-backend-configuration/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation("org.flywaydb:flyway-mysql:${flywayVersion}")
     implementation("org.flywaydb:flyway-database-postgresql:${flywayVersion}")
     implementation("org.postgresql:postgresql")
-    implementation("com.h2database:h2:${h2Version}")
+    implementation("com.h2database:h2")
     implementation("org.mariadb.jdbc:mariadb-java-client:${mariadbJdbcVersion}")
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ import org.cloudfoundry.credhub.gradlebuild.DependenciesGraphPlugin
 
 buildscript {
     ext {
-        apacheCommonsIoVersion = '2.19.0'
         asciiDoctorConvertPluginVersion = '4.0.4'
         bcpkixFipsVersion = '2.1.9'
         bcFipsVersion = '2.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ buildscript {
         commonsCodecVersion = '1.18.0'
         flywayVersion = '11.8.2'
         guavaVersion = '33.4.8-jre'
-        h2Version = '2.3.232'
         kotlinVersion = '2.1.21'
         ktlintVersion = '1.5.0'
         passayVersion = '1.6.6'
@@ -63,7 +62,7 @@ subprojects {
     plugins.withType(JavaPlugin) {
         dependencies {
             implementation("org.yaml:snakeyaml:${snakeyamlVersion}")
-            implementation("com.h2database:h2:${h2Version}")
+            implementation("com.h2database:h2")
             implementation("com.google.guava:guava:${guavaVersion}")
             testImplementation("org.mockito:mockito-core")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
         asciiDoctorConvertPluginVersion = '4.0.4'
         bcpkixFipsVersion = '2.1.9'
         bcFipsVersion = '2.1.0'
-        commonsCodecVersion = '1.18.0'
         flywayVersion = '11.8.2'
         guavaVersion = '33.4.8-jre'
         kotlinVersion = '2.1.21'
@@ -13,7 +12,6 @@ buildscript {
         passayVersion = '1.6.6'
         springBootVersion = '3.4.5'
         mariadbJdbcVersion = '2.7.12' // Bumping to v3 breaks some pipeline jobs, so pinning to v2 for now. v2 (current version) is stable and will be supported until about September 2025 (https://mariadb.com/kb/en/about-mariadb-connector-j/).
-        snakeyamlVersion = '2.4'
         grpcVersion = '1.72.0'
         // We need to stay with protobuf-java & protoc 3.25.x as the latest
         // grpc still depends on protobuf-java & protoc 3.25.x. Once we
@@ -61,7 +59,7 @@ dependencyUpdates.resolutionStrategy = {
 subprojects {
     plugins.withType(JavaPlugin) {
         dependencies {
-            implementation("org.yaml:snakeyaml:${snakeyamlVersion}")
+            implementation("org.yaml:snakeyaml")
             implementation("com.h2database:h2")
             implementation("com.google.guava:guava:${guavaVersion}")
             testImplementation("org.mockito:mockito-core")

--- a/components/auth/build.gradle
+++ b/components/auth/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     testImplementation("org.flywaydb:flyway-database-postgresql:${flywayVersion}")
     implementation("org.postgresql:postgresql")
     implementation("org.mariadb.jdbc:mariadb-java-client:${mariadbJdbcVersion}")
-    implementation("com.h2database:h2:${h2Version}")
+    implementation("com.h2database:h2")
 
     // Other
     api("org.bouncycastle:bc-fips:${bcFipsVersion}")

--- a/components/credentials/build.gradle
+++ b/components/credentials/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     api("org.bouncycastle:bcpkix-fips:${bcpkixFipsVersion}")
     implementation("com.google.guava:guava:${guavaVersion}")
     implementation("org.apache.commons:commons-lang3")
-    implementation("commons-codec:commons-codec:${commonsCodecVersion}")
+    implementation("commons-codec:commons-codec")
     implementation("org.apache.httpcomponents.client5:httpclient5")
     implementation("com.google.protobuf:protobuf-java:${protoBufJavaVersion}")
 }

--- a/components/credentials/build.gradle
+++ b/components/credentials/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation("org.flywaydb:flyway-database-postgresql:${flywayVersion}")
     implementation("org.postgresql:postgresql")
     implementation("org.mariadb.jdbc:mariadb-java-client:${mariadbJdbcVersion}")
-    implementation("com.h2database:h2:${h2Version}")
+    implementation("com.h2database:h2")
 
     // proto
     implementation "io.grpc:grpc-services:${grpcVersion}"

--- a/components/encryption/build.gradle
+++ b/components/encryption/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     api("org.bouncycastle:bcpkix-fips:${bcpkixFipsVersion}")
 
     implementation("org.apache.commons:commons-lang3")
-    implementation("commons-codec:commons-codec:${commonsCodecVersion}")
+    implementation("commons-codec:commons-codec")
 
     //gRPC
     implementation 'javax.annotation:javax.annotation-api:1.3.2'

--- a/components/encryption/build.gradle
+++ b/components/encryption/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     testImplementation("org.flywaydb:flyway-database-postgresql:${flywayVersion}")
     implementation("org.postgresql:postgresql")
     implementation("org.mariadb.jdbc:mariadb-java-client:${mariadbJdbcVersion}")
-    implementation("com.h2database:h2:${h2Version}")
+    implementation("com.h2database:h2")
 
     // Other
     implementation("org.passay:passay:${passayVersion}")

--- a/components/permissions/build.gradle
+++ b/components/permissions/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation("org.flywaydb:flyway-mysql:${flywayVersion}")
     implementation("org.flywaydb:flyway-database-postgresql:${flywayVersion}")
     implementation("org.postgresql:postgresql")
-    implementation("com.h2database:h2:${h2Version}")
+    implementation("com.h2database:h2")
     implementation("org.mariadb.jdbc:mariadb-java-client:${mariadbJdbcVersion}")
 
 

--- a/components/permissions/build.gradle
+++ b/components/permissions/build.gradle
@@ -56,7 +56,6 @@ dependencies {
     // Other
     implementation("com.google.guava:guava:${guavaVersion}")
     implementation("org.apache.commons:commons-lang3")
-    implementation("commons-io:commons-io:${apacheCommonsIoVersion}")
 }
 
 dependencyManagement {


### PR DESCRIPTION
- See individual commits

# notes
- out of scope: the deps brought in by spring boot by default that are major version(s) behind what we explicitly pinned / bring in (don't wanna downgrade anything by a major version, e.g. flyway, even though it's probably not a big deal, since spring boot often values stability).