### PR TITLE
Revert "temp fix: strange h2 column type mismatch error"

### DIFF
--- a/applications/credhub-api/src/main/resources/db/migration/h2/V25_2__relate_named_secrets_to_named_secret_table.sql
+++ b/applications/credhub-api/src/main/resources/db/migration/h2/V25_2__relate_named_secrets_to_named_secret_table.sql
@@ -1,5 +1,5 @@
 ALTER TABLE named_secret
-  ADD COLUMN secret_name_uuid BINARY(16);
+  ADD COLUMN secret_name_uuid VARBINARY(16);
 
 UPDATE named_secret
   SET named_secret.secret_name_uuid = (
@@ -9,7 +9,7 @@ UPDATE named_secret
   );
 
 ALTER TABLE named_secret
-  ALTER COLUMN secret_name_uuid BINARY(16) NOT NULL;
+  ALTER COLUMN secret_name_uuid VARBINARY(16) NOT NULL;
 
 ALTER TABLE named_secret
   ADD CONSTRAINT secret_name_uuid_fkey


### PR DESCRIPTION
This reverts commit fd7d79ba753ad9030400d89fd12ce53b9c87d1f1.

- as we were hoping (see: https://github.com/cloudfoundry/credhub/commit/fd7d79ba753ad9030400d89fd12ce53b9c87d1f1) the original problem went away after the codebase's deps are systematically bumped as a whole.
- so we don't need this "temp fix" (which is not good because it creates a kink, a divergence between h2 and mysql/postgres that we don't want)

[https://vmw-jira.broadcom.net/browse/TNZ-38508]