### PR TITLE
remove: Use of deprecated `WebMvcConfigurer.setUseTrailingSlashMatch()`

### DIFF
--- a/backends/shared-backend-configuration/src/main/kotlin/org/cloudfoundry/credhub/config/WebMvcConfiguration.kt
+++ b/backends/shared-backend-configuration/src/main/kotlin/org/cloudfoundry/credhub/config/WebMvcConfiguration.kt
@@ -6,7 +6,6 @@ import org.cloudfoundry.credhub.interceptors.UserContextInterceptor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
-import org.springframework.web.servlet.config.annotation.PathMatchConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
@@ -17,10 +16,6 @@ class WebMvcConfiguration
         private val userContextInterceptor: UserContextInterceptor,
         private val managementInterceptor: ManagementInterceptor,
     ) : WebMvcConfigurer {
-        override fun configurePathMatch(configurer: PathMatchConfigurer) {
-            configurer.setUseTrailingSlashMatch(true)
-        }
-
         override fun addInterceptors(registry: InterceptorRegistry) {
             registry.addInterceptor(auditInterceptor).excludePathPatterns(
                 "/info",

--- a/components/auth/src/main/java/org/cloudfoundry/credhub/config/AuthConfiguration.java
+++ b/components/auth/src/main/java/org/cloudfoundry/credhub/config/AuthConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
 import org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter;
+import org.springframework.web.filter.UrlHandlerFilter;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -79,6 +80,9 @@ public class AuthConfiguration {
 
         http
                 .addFilterBefore(actuatorPortFilter, X509AuthenticationFilter.class)
+                .addFilterBefore(
+                        UrlHandlerFilter.trailingSlashHandler("/**").wrapRequest().build(),
+                        ActuatorPortFilter.class)
                 .addFilterAfter(preAuthenticationFailureFilter, ActuatorPortFilter.class)
                 .authenticationProvider(preAuthenticatedAuthenticationProvider());
 


### PR DESCRIPTION
- Changed to use `UrlHandlerFilter` instead.
- To keep accepting URLs with trailing slashes.