### PR TITLE
upgrade: Replace use of deprecated `JdbcTemplate.query(String, @Nulla…

### DIFF
--- a/components/test-support/src/test/kotlin/org/cloudfoundry/credhub/config/ParallelMysqlTestDataSourceConfiguration.kt
+++ b/components/test-support/src/test/kotlin/org/cloudfoundry/credhub/config/ParallelMysqlTestDataSourceConfiguration.kt
@@ -29,8 +29,8 @@ class ParallelMysqlTestDataSourceConfiguration {
             jdbcTemplate
                 .query(
                     "SELECT 1 from INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?;",
+                    { rs: ResultSet, _: Int -> rs.getBoolean(1)},
                     arrayOf(workerDatabaseName),
-                    { rs: ResultSet, _: Int -> rs.getBoolean(1) },
                 ).size == 1
 
         if (!doesDatabaseExist) {

--- a/components/test-support/src/test/kotlin/org/cloudfoundry/credhub/config/ParallelPostgresTestDataSourceConfiguration.kt
+++ b/components/test-support/src/test/kotlin/org/cloudfoundry/credhub/config/ParallelPostgresTestDataSourceConfiguration.kt
@@ -29,8 +29,8 @@ class ParallelPostgresTestDataSourceConfiguration {
             jdbcTemplate
                 .query(
                     "SELECT 1 FROM pg_database WHERE datname = ?;",
-                    arrayOf(workerDatabaseName),
                     { rs: ResultSet, _: Int -> rs.getBoolean(1) },
+                    arrayOf(workerDatabaseName),
                 ).size == 1
 
         if (!doesDatabaseExist) {


### PR DESCRIPTION
…ble Object[], RowMapper<T>)`

- With `JdbcTemplate.query(String, RowMapper<T>, @Nullable Object...)`.

For TNZ-44061.