### PR TITLE
fix: Incorrect parameter value

### DIFF
--- a/components/test-support/src/test/kotlin/org/cloudfoundry/credhub/config/ParallelMysqlTestDataSourceConfiguration.kt
+++ b/components/test-support/src/test/kotlin/org/cloudfoundry/credhub/config/ParallelMysqlTestDataSourceConfiguration.kt
@@ -16,7 +16,6 @@ class ParallelMysqlTestDataSourceConfiguration {
 
     private fun createTestDatabaseForWorker(workerId: String) {
         val workerDatabaseName = "credhub_test_$workerId"
-
         val tempDataSource =
             DataSourceBuilder
                 .create()
@@ -24,16 +23,15 @@ class ParallelMysqlTestDataSourceConfiguration {
                 .build()
 
         val jdbcTemplate = JdbcTemplate(tempDataSource)
-
-        val doesDatabaseExist =
+        val noDb =
             jdbcTemplate
                 .query(
                     "SELECT 1 from INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?;",
                     { rs: ResultSet, _: Int -> rs.getBoolean(1) },
-                    arrayOf(workerDatabaseName),
-                ).size == 1
+                    workerDatabaseName,
+                ).isEmpty()
 
-        if (!doesDatabaseExist) {
+        if (noDb) {
             jdbcTemplate.execute("CREATE DATABASE $workerDatabaseName")
         }
 

--- a/components/test-support/src/test/kotlin/org/cloudfoundry/credhub/config/ParallelPostgresTestDataSourceConfiguration.kt
+++ b/components/test-support/src/test/kotlin/org/cloudfoundry/credhub/config/ParallelPostgresTestDataSourceConfiguration.kt
@@ -16,7 +16,6 @@ class ParallelPostgresTestDataSourceConfiguration {
 
     private fun createTestDatabaseForWorker(workerId: String) {
         val workerDatabaseName = "credhub_test_$workerId"
-
         val tempDataSource =
             DataSourceBuilder
                 .create()
@@ -24,16 +23,14 @@ class ParallelPostgresTestDataSourceConfiguration {
                 .build()
 
         val jdbcTemplate = JdbcTemplate(tempDataSource)
-
-        val doesDatabaseExist =
+        val noDb =
             jdbcTemplate
                 .query(
                     "SELECT 1 FROM pg_database WHERE datname = ?;",
                     { rs: ResultSet, _: Int -> rs.getBoolean(1) },
-                    arrayOf(workerDatabaseName),
-                ).size == 1
-
-        if (!doesDatabaseExist) {
+                    workerDatabaseName,
+                ).isEmpty()
+        if (noDb) {
             jdbcTemplate.execute("CREATE DATABASE $workerDatabaseName")
         }
 


### PR DESCRIPTION
- For `jdbcTemplate.query()`.
- Earlier commit to replace the deprecated method version had a mistake.
- Needs to pass `workerDatabaseName` to the new version of the method, not array of `workerDatabaseName`.
- Also refactored the conditional logic to remove double negation.