### PR TITLE
refactor: remove deprecated & unnecessary hibernate usage

### DIFF
--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/Credential.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/Credential.kt
@@ -11,7 +11,6 @@ import jakarta.persistence.Table
 import org.apache.commons.codec.digest.DigestUtils
 import org.cloudfoundry.credhub.audit.AuditableCredential
 import org.cloudfoundry.credhub.constants.UuidConstants.Companion.UUID_BYTES
-import org.hibernate.annotations.GenericGenerator
 import java.util.UUID
 
 @Entity
@@ -20,7 +19,6 @@ class Credential : AuditableCredential {
     @Id
     @Column(length = UUID_BYTES, columnDefinition = "VARBINARY")
     @GeneratedValue(generator = "uuid2")
-    @GenericGenerator(name = "uuid2", strategy = "uuid2")
     override var uuid: UUID? = null
 
     @OneToMany(

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/CredentialVersionData.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/CredentialVersionData.kt
@@ -20,7 +20,6 @@ import org.cloudfoundry.credhub.constants.UuidConstants
 import org.cloudfoundry.credhub.entities.EncryptedValue
 import org.cloudfoundry.credhub.util.InstantMillisecondsConverter
 import org.cloudfoundry.credhub.utils.JsonNodeConverter
-import org.hibernate.annotations.GenericGenerator
 import org.hibernate.annotations.NotFound
 import org.hibernate.annotations.NotFoundAction
 import org.springframework.data.annotation.CreatedDate
@@ -43,7 +42,6 @@ abstract class CredentialVersionData<Z : CredentialVersionData<Z>>(
     @Id
     @Column(length = UuidConstants.UUID_BYTES, columnDefinition = "VARBINARY")
     @GeneratedValue(generator = "uuid2")
-    @GenericGenerator(name = "uuid2", strategy = "uuid2")
     open var uuid: UUID? = null
 
     @OneToOne(cascade = [CascadeType.ALL])

--- a/components/encryption/src/main/java/org/cloudfoundry/credhub/entities/EncryptedValue.java
+++ b/components/encryption/src/main/java/org/cloudfoundry/credhub/entities/EncryptedValue.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.cloudfoundry.credhub.constants.EncryptionConstants;
 import org.cloudfoundry.credhub.constants.UuidConstants;
 import org.cloudfoundry.credhub.util.InstantMillisecondsConverter;
-import org.hibernate.annotations.GenericGenerator;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -33,7 +32,6 @@ public class EncryptedValue {
   @Id
   @Column(length = UuidConstants.UUID_BYTES, columnDefinition = "VARBINARY")
   @GeneratedValue(generator = "uuid2")
-  @GenericGenerator(name = "uuid2", strategy = "uuid2")
   private UUID uuid;
 
   @Convert(converter = InstantMillisecondsConverter.class)

--- a/components/permissions/src/main/kotlin/org/cloudfoundry/credhub/data/PermissionData.kt
+++ b/components/permissions/src/main/kotlin/org/cloudfoundry/credhub/data/PermissionData.kt
@@ -13,7 +13,6 @@ import org.cloudfoundry.credhub.PermissionOperation.WRITE
 import org.cloudfoundry.credhub.PermissionOperation.WRITE_ACL
 import org.cloudfoundry.credhub.audit.AuditablePermissionData
 import org.cloudfoundry.credhub.constants.UuidConstants
-import org.hibernate.annotations.GenericGenerator
 import java.util.UUID
 
 @Entity
@@ -27,7 +26,6 @@ class PermissionData(
     @Id
     @Column(length = UuidConstants.UUID_BYTES, columnDefinition = "VARBINARY")
     @GeneratedValue(generator = "uuid2")
-    @GenericGenerator(name = "uuid2", strategy = "uuid2")
     override var uuid: UUID? = null
 
     @Column(name = "read_permission", nullable = false)


### PR DESCRIPTION
- remove these `@GenericGenerator` which is deprecated
- these usages appear to be unnecessary because:
  - various DB tests still pass without them
  - the various migration guide, when mentioning the replacement of this annotation (`@IdGeneratorType`), the examples are always some custom ID generation logic, whereas the uuid generation logic in our code is generic uuid:
    - https://docs.jboss.org/hibernate/orm/6.5/migration-guide/migration-guide.html#generic-generator
    - https://docs.jboss.org/hibernate/orm/6.4/javadocs/org/hibernate/annotations/IdGeneratorType.html

[https://vmw-jira.broadcom.net/browse/TNZ-44144]