### PR TITLE
replace: Deprecated API calls

### DIFF
--- a/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/SshGenerator.java
+++ b/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/SshGenerator.java
@@ -29,7 +29,7 @@ public class SshGenerator implements CredentialGenerator<SshCredentialValue> {
     try {
       final KeyPair keyPair = keyGenerator.generateKeyPair(params.getKeyLength());
       final String sshComment = params.getSshComment();
-      final String sshCommentMessage = StringUtils.isEmpty(sshComment) ? "" : " " + sshComment;
+      final String sshCommentMessage = StringUtils.hasLength(sshComment) ? " " + sshComment : "";
 
       final String publicKey =
         CertificateFormatter.derOf((RSAPublicKey) keyPair.getPublic()) + sshCommentMessage;

--- a/components/credentials/src/main/java/org/cloudfoundry/credhub/utils/CertificateReader.java
+++ b/components/credentials/src/main/java/org/cloudfoundry/credhub/utils/CertificateReader.java
@@ -81,7 +81,7 @@ public class CertificateReader {
   }
 
   public X500Principal getSubjectName() {
-    return new X500Principal(certificate.getSubjectDN().getName());
+    return new X500Principal(certificate.getSubjectX500Principal().getName());
   }
 
   public boolean isSignedByCa(final String caValue) {
@@ -109,9 +109,9 @@ public class CertificateReader {
   }
 
   public boolean isSelfSigned() {
-    final String issuerName = certificate.getIssuerDN().getName();
+    final String issuerName = certificate.getIssuerX500Principal().getName();
 
-    if (!issuerName.equals(certificate.getSubjectDN().getName())) {
+    if (!issuerName.equals(certificate.getSubjectX500Principal().getName())) {
       return false;
     } else {
       try {

--- a/components/credentials/src/main/java/org/cloudfoundry/credhub/utils/JsonObjectMapper.java
+++ b/components/credentials/src/main/java/org/cloudfoundry/credhub/utils/JsonObjectMapper.java
@@ -5,10 +5,8 @@ import java.io.IOException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.cloudfoundry.credhub.util.TimeModuleFactory;
-
-import static com.fasterxml.jackson.databind.PropertyNamingStrategy.LOWER_CAMEL_CASE;
-import static com.fasterxml.jackson.databind.PropertyNamingStrategy.SNAKE_CASE;
 
 public class JsonObjectMapper {
 
@@ -18,7 +16,7 @@ public class JsonObjectMapper {
     super();
     snakeCaseMapper = new ObjectMapper()
       .registerModule(TimeModuleFactory.Companion.createTimeModule())
-      .setPropertyNamingStrategy(SNAKE_CASE);
+      .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 
   }
 
@@ -32,7 +30,7 @@ public class JsonObjectMapper {
     } catch (final Exception e) {
       final ObjectMapper camelCaseMapper = new ObjectMapper()
         .registerModule(TimeModuleFactory.Companion.createTimeModule())
-        .setPropertyNamingStrategy(LOWER_CAMEL_CASE);
+        .setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE);
       return camelCaseMapper.readValue(stringValue, type);
     }
   }

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/generators/SignedCertificateGeneratorTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/generators/SignedCertificateGeneratorTest.java
@@ -154,8 +154,8 @@ public class SignedCertificateGeneratorTest {
   public void getSelfSigned_generatesACertificateWithTheRightValues() throws Exception {
     final X509Certificate generatedCertificate = subject.getSelfSigned(generatedCertificateKeyPair, certificateGenerationParameters);
 
-    assertThat(generatedCertificate.getIssuerDN().getName(), containsString("CN=my cert name"));
-    assertThat(generatedCertificate.getSubjectDN().toString(), containsString("CN=my cert name"));
+    assertThat(generatedCertificate.getIssuerX500Principal().getName(), containsString("CN=my cert name"));
+    assertThat(generatedCertificate.getSubjectX500Principal().toString(), containsString("CN=my cert name"));
     generatedCertificate.verify(generatedCertificateKeyPair.getPublic());
 
     final byte[] authorityKeyIdDer = generatedCertificate.getExtensionValue(Extension.authorityKeyIdentifier.getId());
@@ -174,13 +174,13 @@ public class SignedCertificateGeneratorTest {
       .getSignedByIssuer(generatedCertificateKeyPair, certificateGenerationParameters,
         certificateAuthorityWithSubjectKeyId, issuerKey.getPrivate());
 
-    assertThat(generatedCertificate.getIssuerDN().getName(), containsString("CN=ca DN"));
-    assertThat(generatedCertificate.getIssuerDN().getName(), containsString("O=credhub"));
+    assertThat(generatedCertificate.getIssuerX500Principal().getName(), containsString("CN=ca DN"));
+    assertThat(generatedCertificate.getIssuerX500Principal().getName(), containsString("O=credhub"));
 
     assertThat(generatedCertificate.getSerialNumber(), equalTo(BigInteger.valueOf(1337L)));
     assertThat(generatedCertificate.getNotBefore().toString(), equalTo(Date.from(now).toString()));
     assertThat(generatedCertificate.getNotAfter().toString(), equalTo(Date.from(later).toString()));
-    assertThat(generatedCertificate.getSubjectDN().toString(), containsString("CN=my cert name"));
+    assertThat(generatedCertificate.getSubjectX500Principal().toString(), containsString("CN=my cert name"));
     assertThat(generatedCertificate.getPublicKey(), equalTo(generatedCertificateKeyPair.getPublic()));
     assertThat(generatedCertificate.getSigAlgName(), equalTo("SHA256WITHRSA"));
     generatedCertificate.verify(issuerKey.getPublic());

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/requests/CertificateGenerationRequestParametersTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/requests/CertificateGenerationRequestParametersTest.java
@@ -320,14 +320,20 @@ public class CertificateGenerationRequestParametersTest {
 
   @Test
   public void validate_rejectsAlternativeNamesThatAreTooLong() {
-    final String maxLengthAlternativeName = RandomStringUtils.randomAlphabetic(57) + "." + RandomStringUtils.randomNumeric(63) +
-      "." + RandomStringUtils.randomAlphabetic(63) + "." + RandomStringUtils.randomAlphabetic(63) + ".com";
+    final String maxLengthAlternativeName =
+            RandomStringUtils.insecure().nextAlphabetic(57)
+                    + "." + RandomStringUtils.insecure().nextNumeric(63) + "."
+                    + RandomStringUtils.insecure().nextAlphabetic(63) + "."
+                    + RandomStringUtils.insecure().nextAlphabetic(63) + ".com";
     subject.setAlternativeNames(new String[]{"abc.com", maxLengthAlternativeName});
     subject.validate();
 
 
-    final String overlyLongAlternativeName = "." + RandomStringUtils.randomAlphabetic(58) + "." + RandomStringUtils.randomNumeric(63) +
-      "." + RandomStringUtils.randomAlphabetic(63) + "." + RandomStringUtils.randomAlphabetic(63) + ".co";
+    final String overlyLongAlternativeName = "."
+            + RandomStringUtils.insecure().nextAlphabetic(58)
+            + "." + RandomStringUtils.insecure().nextNumeric(63) + "."
+            + RandomStringUtils.insecure().nextAlphabetic(63) +
+            "." + RandomStringUtils.insecure().nextAlphabetic(63) + ".co";
     subject.setAlternativeNames(new String[]{"abc.com", overlyLongAlternativeName});
 
     try {

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/services/DefaultCredentialVersionDataServiceTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/services/DefaultCredentialVersionDataServiceTest.java
@@ -62,7 +62,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.IsIterableContaining.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;


### PR DESCRIPTION
- In `:components:credentials`.
- The remaining ones noted in TNZ-44144.