### PR TITLE
replace: Feature that is to be removed in Gradle 9.

### DIFF
--- a/ktlint.gradle
+++ b/ktlint.gradle
@@ -9,7 +9,7 @@ dependencies {
 task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
     classpath = configurations.ktlint
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     args "src/**/*.kt", "!**/db/migration/**/*.kt"
 }
 check.dependsOn ktlint
@@ -17,6 +17,6 @@ check.dependsOn ktlint
 task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
     classpath = configurations.ktlint
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     args "-F", "src/**/*.kt", "!**/db/migration/**/*.kt"
 }


### PR DESCRIPTION
- Replaced one.
- All the remaining deprecation warnings are for the features that are to be removed in Gradle 10.

For TNZ-44286.