### PR TITLE
pin httpcore5 to 5.4.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         mariadbJdbcVersion = '2.7.15' // Bumping to v3 breaks some pipeline jobs, so pinning to v2 for now. v2 (current version) is stable and will be supported until about September 2025 (https://mariadb.com/kb/en/about-mariadb-connector-j/).
         grpcVersion = '1.83.0'
         protobufVersion = '4.35.1'
-        httpcore5Version = '5.4.3'
+        httpcore5Version = '5.4.3' // spring-boot 4.1.0 has this pinned at 5.4.2.  5.4.3 fixes CVE-2026-54399.  Can remove this on future spring-boot update.
     }
     repositories {
         def artifactRepoUrl = System.getenv("ARTIFACTORY_URL")

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         mariadbJdbcVersion = '2.7.15' // Bumping to v3 breaks some pipeline jobs, so pinning to v2 for now. v2 (current version) is stable and will be supported until about September 2025 (https://mariadb.com/kb/en/about-mariadb-connector-j/).
         grpcVersion = '1.83.0'
         protobufVersion = '4.35.1'
+        httpcore5Version = '5.4.3'
     }
     repositories {
         def artifactRepoUrl = System.getenv("ARTIFACTORY_URL")
@@ -82,5 +83,6 @@ subprojects {
 // Override spring boot's version dependencies
 ext['kotlin.version'] = "${kotlinVersion}"
 ext['protobuf-java.version'] = "${protobufVersion}"
+ext['httpcore5.version'] = "${httpcore5Version}"
 
 assert JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_25)


### PR DESCRIPTION
this is beyond the existing spring-boot constraint to resolve CVE-2026-54399